### PR TITLE
Use CODEBUILD_SOURCE_VERSION instead to collect commit ID

### DIFF
--- a/bin/nextflow-stack.ts
+++ b/bin/nextflow-stack.ts
@@ -20,7 +20,6 @@ import {DockerBuildStack} from "../lib/docker-build-stack";
 const app = new App()
 
 
-
 const dev_dockerbuild_stack = new DockerBuildStack(app, "DockerDevStack", {
   env: AWS_ENV_DEV,
   stackName: "DockerBuild",

--- a/bin/nextflow-stack.ts
+++ b/bin/nextflow-stack.ts
@@ -29,6 +29,7 @@ const dev_dockerbuild_stack = new DockerBuildStack(app, "DockerDevStack", {
 const dev_application_stack = new NextflowApplicationStack(app, 'NextflowApplicationDevStack', {
   env: AWS_ENV_DEV,
   stack_name: "NextflowStack",
+  docker_tag: dev_dockerbuild_stack.dockerTag.toString(),
   ssm_parameters: SSM_PARAMETERS["DEV"],
   cache_bucket: NXF_CACHE_BUCKET_DEV,
   cache_prefix: NXF_CACHE_PREFIX_DEV,

--- a/bin/nextflow-stack.ts
+++ b/bin/nextflow-stack.ts
@@ -23,8 +23,7 @@ const app = new App()
 const dev_dockerbuild_stack = new DockerBuildStack(app, "DockerDevStack", {
   env: AWS_ENV_DEV,
   stackName: "DockerBuild",
-  tag_date: "19700101",
-  commit_id: "abcdefg"
+  tag: "dev"
 });
 
 const dev_application_stack = new NextflowApplicationStack(app, 'NextflowApplicationDevStack', {

--- a/lib/application-stack.ts
+++ b/lib/application-stack.ts
@@ -8,6 +8,7 @@ import {StringParameter} from "aws-cdk-lib/aws-ssm";
 
 interface NextflowApplicationBuildStackProps extends StackProps {
     env: Environment,
+    docker_tag?: string,
     stack_name: string,
     cache_bucket: string,
     cache_prefix: string,
@@ -26,6 +27,19 @@ export class NextflowApplicationStack extends Stack {
         props: NextflowApplicationBuildStackProps,
     ) {
         super(scope, id, props);
+
+        // Add in docker tag that we've collected from the inputs
+        if (props.docker_tag !== undefined){
+            new StringParameter(
+                this,
+                `ssm-parameter-docker-tag`,
+                {
+                    parameterName: "/oncoanalyser/docker/tag",
+                    stringValue: props.docker_tag
+                }
+            )
+        }
+
 
         const shared = new SharedStack(this, 'NextflowSharedStack', {
             env: props.env,
@@ -72,6 +86,7 @@ export class NextflowApplicationStack extends Stack {
 
 interface NextflowApplicationBuildStageProps extends StackProps {
     env: Environment,
+    docker_tag: string,
     stack_name: string,
     cache_bucket: string,
     cache_prefix: string,

--- a/lib/docker-build-stack.ts
+++ b/lib/docker-build-stack.ts
@@ -51,16 +51,6 @@ export class DockerBuildStack extends Stack {
             value: docker_dest.uri,
         });
 
-        // Add in ssm parameters for batch instance role name
-        new StringParameter(
-            this,
-            `ssm-parameter-docker-tag`,
-            {
-                parameterName: "/oncoanalyser/docker/tag",
-                stringValue: docker_dest.toString()
-            }
-        )
-
     }
 }
 
@@ -72,6 +62,8 @@ interface DockerBuildStageProps extends StackProps {
 
 export class DockerBuildStage extends Stage {
 
+    public readonly dockerTag: CfnOutput;
+
     constructor(
         scope: Construct,
         id: string,
@@ -82,5 +74,7 @@ export class DockerBuildStage extends Stage {
         const docker_build_stack = new DockerBuildStack(this, "DockerBuild", props);
 
         Tags.of(docker_build_stack).add("Stack", props.stack_name);
+
+        this.dockerTag = docker_build_stack.dockerTag
     }
 }

--- a/lib/docker-build-stack.ts
+++ b/lib/docker-build-stack.ts
@@ -22,8 +22,7 @@ import {
 
 interface IDockerBuildStackProps extends StackProps {
     env: Environment
-    tag_date: string
-    commit_id: string
+    tag: string
 }
 
 // The Docker Build Stack deploys
@@ -41,7 +40,7 @@ export class DockerBuildStack extends Stack {
             directory: pathjoin(__dirname, '../', 'docker-images', 'oncoanalyser'),
         });
 
-        const docker_dest = new DockerImageName(`${props.env.account}.dkr.ecr.${props.env.region}.amazonaws.com/oncoanalyser:${props.tag_date}--${props.commit_id}`)
+        const docker_dest = new DockerImageName(`${props.env.account}.dkr.ecr.${props.env.region}.amazonaws.com/oncoanalyser:${props.tag}`)
 
         new ECRDeployment(this, 'DeployDockerImage', {
             src: new DockerImageName(image.imageUri),
@@ -57,8 +56,7 @@ export class DockerBuildStack extends Stack {
 
 interface DockerBuildStageProps extends StackProps {
     env: Environment,
-    tag_date: string,
-    commit_id: string
+    tag: string,
     stack_name: string
 }
 

--- a/lib/pipeline-stack.ts
+++ b/lib/pipeline-stack.ts
@@ -119,7 +119,7 @@ export class NextflowBuildPipelineStack extends Stack {
             stack_name: "oncoanalyser",
             // See https://github.com/aws/aws-cdk/issues/20643#issuecomment-1219565988 for more info as to how this works
             // Also inspired by https://stackoverflow.com/questions/74979993/how-do-i-obtain-exposed-variables-from-codebuild-in-the-cdk
-            tag: tag_date + "--" + process.env.CODEBUILD_SOURCE_VERSION
+            tag: tag_date + "--" + process.env.CODEBUILD_RESOLVED_SOURCE_VERSION
         })
 
         // Add Docker stage to pipeline

--- a/lib/pipeline-stack.ts
+++ b/lib/pipeline-stack.ts
@@ -53,7 +53,7 @@ export class NextflowBuildPipelineStack extends Stack {
             "codestar_github_arn"
         );
 
-        const input_source = pipelines.CodePipelineSource.connection("umccr/nextflow-stack", "main", {
+        const input_source = pipelines.CodePipelineSource.connection("umccr/nextflow-stack", "pipeline-test", {
             connectionArn: codeStarArn,
             codeBuildCloneOutput: true
         })
@@ -113,11 +113,13 @@ export class NextflowBuildPipelineStack extends Stack {
 
         // Build docker image (shared stack between staging and dev)
         const tag_date = (moment(new Date())).format('YYYYMMDDHHmmSS')
+
         const dockerStage = new DockerBuildStage(this, "BuildDockerImage", {
             env: AWS_ENV_BUILD,
             stack_name: "oncoanalyser",
             // See https://github.com/aws/aws-cdk/issues/20643#issuecomment-1219565988 for more info as to how this works
-            tag: tag_date + "--" + "#{Source@umccr_nextflow-stack.CommitId}"
+            // Also inspired by https://stackoverflow.com/questions/74979993/how-do-i-obtain-exposed-variables-from-codebuild-in-the-cdk
+            tag: tag_date + "--" + process.env.CODEBUILD_SOURCE_VERSION
         })
 
         // Add Docker stage to pipeline

--- a/lib/pipeline-stack.ts
+++ b/lib/pipeline-stack.ts
@@ -53,7 +53,7 @@ export class NextflowBuildPipelineStack extends Stack {
             "codestar_github_arn"
         );
 
-        const input_source = pipelines.CodePipelineSource.connection("umccr/nextflow-stack", "pipeline-test", {
+        const input_source = pipelines.CodePipelineSource.connection("umccr/nextflow-stack", "main", {
             connectionArn: codeStarArn,
             codeBuildCloneOutput: true
         })

--- a/lib/pipeline-stack.ts
+++ b/lib/pipeline-stack.ts
@@ -114,14 +114,15 @@ export class NextflowBuildPipelineStack extends Stack {
         // Build docker image (shared stack between staging and dev)
         const tag_date = (moment(new Date())).format('YYYYMMDDHHmmSS')
 
-        const commit_id = process.env.CODEBUILD_RESOLVED_SOURCE_VERSION || "latest"
+        // Collect the commit id (use 'latest' if running synth locally)
+        const commit_id = (process.env.CODEBUILD_RESOLVED_SOURCE_VERSION || "latest").substring(0, 8)
 
         const dockerStage = new DockerBuildStage(this, "BuildDockerImage", {
             env: AWS_ENV_BUILD,
             stack_name: "oncoanalyser",
             // See https://github.com/aws/aws-cdk/issues/20643#issuecomment-1219565988 for more info as to how this works
             // Also inspired by https://stackoverflow.com/questions/74979993/how-do-i-obtain-exposed-variables-from-codebuild-in-the-cdk
-            tag: tag_date + "--" + commit_id.substring(0, 8)
+            tag: tag_date + "--" + commit_id
         })
 
         const docker_tag = dockerStage.dockerTag.toString()

--- a/lib/pipeline-stack.ts
+++ b/lib/pipeline-stack.ts
@@ -114,12 +114,14 @@ export class NextflowBuildPipelineStack extends Stack {
         // Build docker image (shared stack between staging and dev)
         const tag_date = (moment(new Date())).format('YYYYMMDDHHmmSS')
 
+        const commit_id = <string>process.env.CODEBUILD_RESOLVED_SOURCE_VERSION
+
         const dockerStage = new DockerBuildStage(this, "BuildDockerImage", {
             env: AWS_ENV_BUILD,
             stack_name: "oncoanalyser",
             // See https://github.com/aws/aws-cdk/issues/20643#issuecomment-1219565988 for more info as to how this works
             // Also inspired by https://stackoverflow.com/questions/74979993/how-do-i-obtain-exposed-variables-from-codebuild-in-the-cdk
-            tag: tag_date + "--" + process.env.CODEBUILD_RESOLVED_SOURCE_VERSION
+            tag: tag_date + "--" + commit_id.substring(0, 8)
         })
 
         // Add Docker stage to pipeline

--- a/lib/pipeline-stack.ts
+++ b/lib/pipeline-stack.ts
@@ -1,4 +1,4 @@
-import {CfnOutput, Environment, pipelines, Stack, StackProps} from "aws-cdk-lib";
+import {Environment, pipelines, Stack, StackProps} from "aws-cdk-lib";
 
 import {Construct} from "constructs";
 


### PR DESCRIPTION
## Docker Tag updates

* Output docker tag as CfnOutput of docker build stack
* Set docker tag ssm parameter in Nextflow Application Stack
* Parse docker tag between the two in codepipeline for stg/prod and in the app bin for dev



