### PR TITLE
Adjust for ORANGE WTS support in oncoanalyser

### DIFF
--- a/application/pipeline-stacks/oncoanalyser/assets/nextflow_aws.template.config
+++ b/application/pipeline-stacks/oncoanalyser/assets/nextflow_aws.template.config
@@ -87,6 +87,12 @@ process {
     memory = 30.GB
   }
 
+  withName: '.*:SAGE_APPEND:(?:GERMLINE|SOMATIC)' {
+    executor = 'local'
+    cpus = 1
+    memory = 12.GB
+  }
+
   withName: '.*:PAVE_ANNOTATION:GERMLINE' {
     queue = 'nextflow-task-2cpu_16gb-spot'
     cpus = 2

--- a/application/settings.ts
+++ b/application/settings.ts
@@ -13,7 +13,7 @@ export function getSettings(envName: string, workflowName: string) {
     ["refdataPrefix", "workflow_data"],
     // oncoanalyser
     ["refdataGenomesPath", "genomes"],
-    ["refdataHmfPath", "hmf_reference_data/repacks/5.32_38_0.0.1"],
+    ["refdataHmfPath", "hmf_reference_data/repacks/5.32_38_0.0.2"],
     ["refDataVirusbreakendDbPath", "virusbreakend/virusbreakenddb_20210401"],
     // star-align-nf
     ["refdataStarIndexPath", "genomes/GRCh38_umccr/star_index/gencode_38/2.7.3a"],


### PR DESCRIPTION
- Add AWS configuration to run SAGE append locally
- Use HMF reference repack `5.32_38_0.0.2`, which includes new WTS cohort files