### PR TITLE
Adjust max vCPUs for Batch job queues

### DIFF
--- a/application/base-pipeline-stack.ts
+++ b/application/base-pipeline-stack.ts
@@ -30,9 +30,10 @@ import {getBaseBatchInstancePipelineRole, getRoleBatchInstanceTask} from "./base
 
 
 interface IBatchComputeData {
-  name: string,
-  costModel: ComputeResourceType,
-  instances: string[],
+  name: string;
+  costModel: ComputeResourceType;
+  instances: string[];
+  maxvCpus?: number;
 }
 
 // NOTE(SW): allowing only exactly one pipeline queue/env for now
@@ -122,6 +123,8 @@ const batchComputeTask: IBatchComputeData[] = [
       'c5d.4xlarge',
       'c6id.4xlarge',
     ],
+    // NOTE(SW): allow up to 16 concurrent jobs
+    maxvCpus: 256,
   },
 
   /*
@@ -306,7 +309,7 @@ chmod 777 /mnt/local_ephemeral/
           launchTemplateId: args.launchTemplate.launchTemplateId as string,
           version: '$Latest',
         },
-        maxvCpus: 128,
+        maxvCpus: args.batchComputeData.maxvCpus ?? 128,
         securityGroups: [args.securityGroup],
         spotFleetRole: args.roleBatchSpotfleet,
         vpcSubnets: {


### PR DESCRIPTION
**Background**

- we currently use a flat 128 max vCPU limit for all Batch job queues
- this has been overly restrictive for job queues with higher vCPU count per task
- e.g. more than 4 oncoanalyser runs will oversaturate the 16cpu_32gb queue

**Change summary**

- allow the Batch compute config to optionally set a non-default value for max vCPUs
- adjust the number of max vCPUs for the 16cpu_32gb queue from 128 to 256 (allowing up to 16 concurrent jobs)