### PR TITLE
Provide metadata information through Batch job parameters

### DIFF
--- a/application/application-stack.ts
+++ b/application/application-stack.ts
@@ -8,7 +8,7 @@ import {
   Tags,
 } from "aws-cdk-lib";
 
-import {getSettings} from './settings';
+import * as settings from './settings';
 import {BasePipelineStack} from './base-pipeline-stack';
 
 import {OncoanalyserStack} from './pipeline-stacks/oncoanalyser/stack';
@@ -63,43 +63,52 @@ export class ApplicationStack extends Stack {
   }
 
   buildOncoanalyserStack(args: IBuildStack) {
-    const settings = getSettings(args.envName, args.workflowName);
+    const stackSettings = new settings.Oncoanalyser(args.envName, args.workflowName);
+    const s3Data = stackSettings.getS3Data();
+
     const pipelineStack = new OncoanalyserStack(this, 'OncoanalyserStack', {
       ...args,
-      nfBucketName: settings.s3Data.get('nfBucketName')!,
-      nfPrefixTemp: settings.s3Data.get('nfPrefixTemp')!,
-      nfPrefixOutput: settings.s3Data.get('nfPrefixOutput')!,
-      refdataBucketName: settings.s3Data.get('refdataBucketName')!,
-      refdataPrefix: settings.s3Data.get('refdataPrefix')!,
-      ssmParameters: settings.ssmParameters,
+      pipelineVersionTag: stackSettings.versionTag,
+      nfBucketName: s3Data.get('nfBucketName')!,
+      nfPrefixTemp: s3Data.get('nfPrefixTemp')!,
+      nfPrefixOutput: s3Data.get('nfPrefixOutput')!,
+      refdataBucketName: s3Data.get('refdataBucketName')!,
+      refdataPrefix: s3Data.get('refdataPrefix')!,
+      ssmParameters: stackSettings.getSsmParameters(),
     });
     Tags.of(pipelineStack).add('Stack', 'OncoanalyserStack');
   }
 
   buildSashStack(args: IBuildStack) {
-    const settings = getSettings(args.envName, args.workflowName);
+    const stackSettings = new settings.Sash(args.envName, args.workflowName);
+    const s3Data = stackSettings.getS3Data();
+
     const pipelineStack = new StarAlignNfStack(this, 'SashStack', {
       ...args,
-      nfBucketName: settings.s3Data.get('nfBucketName')!,
-      nfPrefixTemp: settings.s3Data.get('nfPrefixTemp')!,
-      nfPrefixOutput: settings.s3Data.get('nfPrefixOutput')!,
-      refdataBucketName: settings.s3Data.get('refdataBucketName')!,
-      refdataPrefix: settings.s3Data.get('refdataPrefix')!,
-      ssmParameters: settings.ssmParameters,
+      pipelineVersionTag: stackSettings.versionTag,
+      nfBucketName: s3Data.get('nfBucketName')!,
+      nfPrefixTemp: s3Data.get('nfPrefixTemp')!,
+      nfPrefixOutput: s3Data.get('nfPrefixOutput')!,
+      refdataBucketName: s3Data.get('refdataBucketName')!,
+      refdataPrefix: s3Data.get('refdataPrefix')!,
+      ssmParameters: stackSettings.getSsmParameters(),
     });
     Tags.of(pipelineStack).add('Stack', 'SashStack');
   }
 
   buildStarAlignNfStack(args: IBuildStack) {
-    const settings = getSettings(args.envName, args.workflowName);
+    const stackSettings = new settings.StarAlignNf(args.envName, args.workflowName);
+    const s3Data = stackSettings.getS3Data();
+
     const pipelineStack = new StarAlignNfStack(this, 'StarAlignNfStack', {
       ...args,
-      nfBucketName: settings.s3Data.get('nfBucketName')!,
-      nfPrefixTemp: settings.s3Data.get('nfPrefixTemp')!,
-      nfPrefixOutput: settings.s3Data.get('nfPrefixOutput')!,
-      refdataBucketName: settings.s3Data.get('refdataBucketName')!,
-      refdataPrefix: settings.s3Data.get('refdataPrefix')!,
-      ssmParameters: settings.ssmParameters,
+      pipelineVersionTag: stackSettings.versionTag,
+      nfBucketName: s3Data.get('nfBucketName')!,
+      nfPrefixTemp: s3Data.get('nfPrefixTemp')!,
+      nfPrefixOutput: s3Data.get('nfPrefixOutput')!,
+      refdataBucketName: s3Data.get('refdataBucketName')!,
+      refdataPrefix: s3Data.get('refdataPrefix')!,
+      ssmParameters: stackSettings.getSsmParameters(),
     });
     Tags.of(pipelineStack).add('Stack', 'StarAlignNfStack');
   }

--- a/application/pipeline-stacks/common.ts
+++ b/application/pipeline-stacks/common.ts
@@ -20,6 +20,7 @@ import {createPipelineRoles} from "../base-roles";
 interface IDockerImageBuild extends StackProps {
   env: Environment;
   workflowName: string;
+  gitReference: string;
   dockerTag?: string;
 }
 
@@ -27,6 +28,7 @@ export interface IPipelineStack extends StackProps {
   env: Environment;
   envBuild: Environment;
   workflowName: string;
+  pipelineVersionTag: string;
   dockerTag?: string;
   jobQueuePipelineArn: string;
   jobQueueTaskArns: Map<string, string>;
@@ -47,6 +49,7 @@ export class PipelineStack extends Stack {
     const dockerStack = new DockerImageBuildStack(this, `DockerImageBuildStack-${props.workflowName}`, {
       env: props.envBuild,
       workflowName: props.workflowName,
+      gitReference: props.pipelineVersionTag,
       dockerTag: props.dockerTag,
     });
 
@@ -172,6 +175,7 @@ export class DockerImageBuildStack extends Stack {
     const dockerTag = props.dockerTag || "latest";
 
     const image = new DockerImageAsset(this, `CDKDockerImage-${props.workflowName}`, {
+      buildArgs: { 'PIPELINE_GITHUB_REF': props.gitReference },
       directory: pathjoin(__dirname, props.workflowName),
     });
 

--- a/application/pipeline-stacks/oncoanalyser/Dockerfile
+++ b/application/pipeline-stacks/oncoanalyser/Dockerfile
@@ -20,8 +20,11 @@ ARG DOCKER_CE_VERSION="23.0.1-1"
 ARG DOCKER_COMPOSE_VERSION="2.16.0-1"
 
 # Pipeline GH URL and branch/tag
-ARG PIPELINE_GITHUB_REF="v0.1.0"
+ARG PIPELINE_GITHUB_REF  // NOTE(SW): must be provided as build argument
 ARG PIPELINE_GITHUB_REPO_URL="https://github.com/scwatts/oncoanalyser.git"
+
+RUN \
+  test -n "${PIPELINE_GITHUB_REF}" || (echo "PIPELINE_GITHUB_REF must be set" && false)
 
 # Configure Conda
 RUN \

--- a/application/pipeline-stacks/oncoanalyser/lambda_functions/batch_job_submission/lambda_code.py
+++ b/application/pipeline-stacks/oncoanalyser/lambda_functions/batch_job_submission/lambda_code.py
@@ -62,6 +62,10 @@ def main(event, context):
                 {'type': 'VCPU', 'value': '2'},
             ],
         },
+        parameters={
+            'portal_run_id': event['portal_run_id'],
+            'subject_id': event['subject_id'],
+        },
     )
 
     LOGGER.info(f'Received job submission response: {response_job}')

--- a/application/pipeline-stacks/oncoanalyser/lambda_functions/batch_job_submission/lambda_code.py
+++ b/application/pipeline-stacks/oncoanalyser/lambda_functions/batch_job_submission/lambda_code.py
@@ -49,6 +49,13 @@ def main(event, context):
 
     job_data = get_job_data(event)
 
+    output_directory = get_output_results_dir(
+        event['subject_id'],
+        get_library_id_string(event),
+        event['portal_run_id'],
+        event['mode'],
+    )
+
     LOGGER.info(f'Compiled job data: {job_data}')
 
     response_job = CLIENT_BATCH.submit_job(
@@ -66,6 +73,7 @@ def main(event, context):
             'portal_run_id': event['portal_run_id'],
             'workflow': f'oncoanalyser_{event["mode"]}',
             'version': get_ssm_parameter_value('/nextflow_stack/oncoanalyser/pipeline_version_tag'),
+            'output': json.dumps({'output_directory': output_directory}),
         },
     )
 
@@ -105,13 +113,42 @@ def get_library_id_string(event):
     return '__'.join(lid for lid in library_ids if lid)
 
 
+def get_output_results_dir(subject_id, library_id_str, portal_run_id, mode):
+
+    bucket_name = get_ssm_parameter_value('/nextflow_stack/oncoanalyser/nf_bucket_name')
+    return f's3://{bucket_name}/analysis_data/{subject_id}/oncoanalyser/{portal_run_id}/{mode}/{library_id_str}'
+
+
+def get_output_scratch_dir(subject_id, portal_run_id):
+
+    bucket_name = get_ssm_parameter_value('/nextflow_stack/oncoanalyser/nf_bucket_name')
+    return f's3://{bucket_name}/temp_data/{subject_id}/oncoanalyser/{portal_run_id}/scratch'
+
+def get_output_staging_dir(subject_id, portal_run_id):
+
+    bucket_name = get_ssm_parameter_value('/nextflow_stack/oncoanalyser/nf_bucket_name')
+    return f's3://{bucket_name}/temp_data/{subject_id}/oncoanalyser/{portal_run_id}/staging'
+
+
 def get_job_command(event):
+
+    output_results_dir = get_output_results_dir(
+        event['subject_id'],
+        get_library_id_string(event),
+        event['portal_run_id'],
+        event['mode'],
+    )
+    output_scratch_dir = get_output_scratch_dir(event['subject_id'], event['portal_run_id'])
+    output_staging_dir = get_output_staging_dir(event['subject_id'], event['portal_run_id'])
 
     command_components = [
         './assets/run.sh',
         f'--portal_run_id {event["portal_run_id"]}',
         f'--mode {event["mode"]}',
         f'--subject_id {event["subject_id"]}',
+        f'--output_results_dir {output_results_dir}',
+        f'--output_staging_dir {output_scratch_dir}',
+        f'--output_scratch_dir {output_staging_dir}',
     ]
 
     command_components_wgs = [

--- a/application/pipeline-stacks/oncoanalyser/lambda_functions/batch_job_submission/lambda_code.py
+++ b/application/pipeline-stacks/oncoanalyser/lambda_functions/batch_job_submission/lambda_code.py
@@ -64,7 +64,8 @@ def main(event, context):
         },
         parameters={
             'portal_run_id': event['portal_run_id'],
-            'subject_id': event['subject_id'],
+            'workflow': f'oncoanalyser_{event["mode"]}',
+            'version': get_ssm_parameter_value('/nextflow_stack/oncoanalyser/pipeline_version_tag'),
         },
     )
 

--- a/application/pipeline-stacks/sash/Dockerfile
+++ b/application/pipeline-stacks/sash/Dockerfile
@@ -19,8 +19,11 @@ ARG DOCKER_CE_VERSION="23.0.1-1"
 ARG DOCKER_COMPOSE_VERSION="2.16.0-1"
 
 # Pipeline GH URL and branch/tag
+ARG PIPELINE_GITHUB_REF  // NOTE(SW): must be provided as build argument
 ARG PIPELINE_GITHUB_REPO_URL="https://github.com/scwatts/sash.git"
-ARG PIPELINE_GITHUB_REF="v0.1.1"
+
+RUN \
+  test -n "${PIPELINE_GITHUB_REF}" || (echo "PIPELINE_GITHUB_REF must be set" && false)
 
 # Configure Conda
 RUN \

--- a/application/pipeline-stacks/sash/lambda_functions/batch_job_submission/lambda_code.py
+++ b/application/pipeline-stacks/sash/lambda_functions/batch_job_submission/lambda_code.py
@@ -57,6 +57,10 @@ def main(event, context):
                 {'type': 'VCPU', 'value': '2'},
             ],
         },
+        parameters={
+            'portal_run_id': event['portal_run_id'],
+            'subject_id': event['subject_id'],
+        },
     )
 
     LOGGER.info(f'Received job submission response: {response_job}')

--- a/application/pipeline-stacks/sash/lambda_functions/batch_job_submission/lambda_code.py
+++ b/application/pipeline-stacks/sash/lambda_functions/batch_job_submission/lambda_code.py
@@ -44,6 +44,13 @@ def main(event, context):
 
     job_data = get_job_data(event)
 
+    output_directory = get_output_results_dir(
+        event['subject_id'],
+        event['tumor_library_id'],
+        event['normal_library_id'],
+        event['portal_run_id'],
+    )
+
     LOGGER.info(f'Compiled job data: {job_data}')
 
     response_job = CLIENT_BATCH.submit_job(
@@ -61,6 +68,7 @@ def main(event, context):
             'portal_run_id': event['portal_run_id'],
             'workflow': 'sash',
             'version': get_ssm_parameter_value('/nextflow_stack/sash/pipeline_version_tag'),
+            'output': json.dumps({'output_directory': output_directory}),
         },
     )
 
@@ -91,7 +99,34 @@ def get_ssm_parameter_value(name):
     return response['Parameter']['Value']
 
 
+def get_output_results_dir(subject_id, tumor_library_id, normal_library_id, portal_run_id):
+
+    bucket_name = get_ssm_parameter_value('/nextflow_stack/sash/nf_bucket_name')
+    return f's3://{bucket_name}/analysis_data/{subject_id}/sash/{portal_run_id}/{tumor_library_id}_{normal_library_id}'
+
+
+def get_output_scratch_dir(subject_id, portal_run_id):
+
+    bucket_name = get_ssm_parameter_value('/nextflow_stack/sash/nf_bucket_name')
+    return f's3://{bucket_name}/temp_data/{subject_id}/sash/{portal_run_id}/scratch'
+
+
+def get_output_staging_dir(subject_id, portal_run_id):
+
+    bucket_name = get_ssm_parameter_value('/nextflow_stack/sash/nf_bucket_name')
+    return f's3://{bucket_name}/temp_data/{subject_id}/sash/{portal_run_id}/staging'
+
+
 def get_job_command(event):
+
+    output_results_dir = get_output_results_dir(
+        event['subject_id'],
+        event['tumor_library_id'],
+        event['normal_library_id'],
+        event['portal_run_id'],
+    )
+    output_scratch_dir = get_output_scratch_dir(event['subject_id'], event['portal_run_id'])
+    output_staging_dir = get_output_staging_dir(event['subject_id'], event['portal_run_id'])
 
     command_components = [
         './assets/run.sh',
@@ -104,6 +139,9 @@ def get_job_command(event):
         f'--dragen_somatic_dir {event["dragen_somatic_dir"]}',
         f'--dragen_germline_dir {event["dragen_germline_dir"]}',
         f'--oncoanalyser_dir {event["oncoanalyser_dir"]}',
+        f'--output_results_dir {output_results_dir}',
+        f'--output_staging_dir {output_scratch_dir}',
+        f'--output_scratch_dir {output_staging_dir}',
     ]
 
     return ['bash', '-o', 'pipefail', '-c', ' '.join(command_components)]

--- a/application/pipeline-stacks/sash/lambda_functions/batch_job_submission/lambda_code.py
+++ b/application/pipeline-stacks/sash/lambda_functions/batch_job_submission/lambda_code.py
@@ -59,7 +59,8 @@ def main(event, context):
         },
         parameters={
             'portal_run_id': event['portal_run_id'],
-            'subject_id': event['subject_id'],
+            'workflow': 'sash',
+            'version': get_ssm_parameter_value('/nextflow_stack/sash/pipeline_version_tag'),
         },
     )
 

--- a/application/pipeline-stacks/star-align-nf/Dockerfile
+++ b/application/pipeline-stacks/star-align-nf/Dockerfile
@@ -20,8 +20,11 @@ ARG DOCKER_CE_VERSION="23.0.1-1"
 ARG DOCKER_COMPOSE_VERSION="2.16.0-1"
 
 # Pipeline GH URL and branch/tag
+ARG PIPELINE_GITHUB_REF  // NOTE(SW): must be provided as build argument
 ARG PIPELINE_GITHUB_REPO_URL="https://github.com/scwatts/star-align-nf.git"
-ARG PIPELINE_GITHUB_REF="v0.1.0"
+
+RUN \
+  test -n "${PIPELINE_GITHUB_REF}" || (echo "PIPELINE_GITHUB_REF must be set" && false)
 
 # Configure Conda
 RUN \

--- a/application/pipeline-stacks/star-align-nf/lambda_functions/batch_job_submission/lambda_code.py
+++ b/application/pipeline-stacks/star-align-nf/lambda_functions/batch_job_submission/lambda_code.py
@@ -41,6 +41,12 @@ def main(event, context):
 
     job_data = get_job_data(event)
 
+    output_directory = get_output_results_dir(
+        event['subject_id'],
+        event['library_id'],
+        event['portal_run_id'],
+    )
+
     LOGGER.info(f'Compiled job data: {job_data}')
 
     response_job = CLIENT_BATCH.submit_job(
@@ -58,6 +64,7 @@ def main(event, context):
             'portal_run_id': event['portal_run_id'],
             'workflow': 'star_alignment',
             'version': get_ssm_parameter_value('/nextflow_stack/star-align-nf/pipeline_version_tag'),
+            'output': json.dumps({'output_directory': output_directory}),
         },
     )
 
@@ -88,7 +95,33 @@ def get_ssm_parameter_value(name):
     return response['Parameter']['Value']
 
 
+def get_output_results_dir(subject_id, library_id, portal_run_id):
+
+    bucket_name = get_ssm_parameter_value('/nextflow_stack/star-align-nf/nf_bucket_name')
+    return f's3://{bucket_name}/analysis_data/{subject_id}/star-align-nf/{portal_run_id}/{library_id}'
+
+
+def get_output_scratch_dir(subject_id, portal_run_id):
+
+    bucket_name = get_ssm_parameter_value('/nextflow_stack/star-align-nf/nf_bucket_name')
+    return f's3://{bucket_name}/temp_data/{subject_id}/star-align-nf/{portal_run_id}/scratch'
+
+
+def get_output_staging_dir(subject_id, portal_run_id):
+
+    bucket_name = get_ssm_parameter_value('/nextflow_stack/star-align-nf/nf_bucket_name')
+    return f's3://{bucket_name}/temp_data/{subject_id}/star-align-nf/{portal_run_id}/staging'
+
+
 def get_job_command(event):
+
+    output_results_dir = get_output_results_dir(
+        event['subject_id'],
+        event['library_id'],
+        event['portal_run_id'],
+    )
+    output_scratch_dir = get_output_scratch_dir(event['subject_id'], event['portal_run_id'])
+    output_staging_dir = get_output_staging_dir(event['subject_id'], event['portal_run_id'])
 
     command_components = [
         './assets/run.sh',
@@ -98,6 +131,9 @@ def get_job_command(event):
         f'--library_id {event["library_id"]}',
         f'--fastq_fwd {event["fastq_fwd"]}',
         f'--fastq_rev {event["fastq_rev"]}',
+        f'--output_results_dir {output_results_dir}',
+        f'--output_staging_dir {output_scratch_dir}',
+        f'--output_scratch_dir {output_staging_dir}',
     ]
 
     return ['bash', '-o', 'pipefail', '-c', ' '.join(command_components)]

--- a/application/pipeline-stacks/star-align-nf/lambda_functions/batch_job_submission/lambda_code.py
+++ b/application/pipeline-stacks/star-align-nf/lambda_functions/batch_job_submission/lambda_code.py
@@ -54,6 +54,10 @@ def main(event, context):
                 {'type': 'VCPU', 'value': '2'},
             ],
         },
+        parameters={
+            'portal_run_id': event['portal_run_id'],
+            'subject_id': event['subject_id'],
+        },
     )
 
     LOGGER.info(f'Received job submission response: {response_job}')

--- a/application/pipeline-stacks/star-align-nf/lambda_functions/batch_job_submission/lambda_code.py
+++ b/application/pipeline-stacks/star-align-nf/lambda_functions/batch_job_submission/lambda_code.py
@@ -56,7 +56,8 @@ def main(event, context):
         },
         parameters={
             'portal_run_id': event['portal_run_id'],
-            'subject_id': event['subject_id'],
+            'workflow': 'star_alignment',
+            'version': get_ssm_parameter_value('/nextflow_stack/star-align-nf/pipeline_version_tag'),
         },
     )
 


### PR DESCRIPTION
Changes:

- add workflow metadata to Batch job parameters for downstream operations
- include only Portal run ID, workflow name, workflow version, output base directory for now
- workflow output directories now set in Lambdas and passed to run.sh in Batch job command
- configure workflow name and version through the respective settings class

Example:

_CW log /aws/lambda/event-format-observer (2023/09/07/[$LATEST]03ce49d6616e4a449c768b3cb31834f0)_

> `.Records[0].body | fromjson | .detail.parameters`

```json
{
  "portal_run_id": "20230908wgsaaaaa",
  "workflow": "oncoanalyser_wgs",
  "version": "v0.1.0",
  "output": {"output_directory": "s3://umccr-temp-dev/analysis_data/SBJ00910/oncoanalyser/20230908wgsaaaaa/wgs/L2100746__L2100745"}
}
```