### PR TITLE
Use git tags as refs in Dockerfile

### DIFF
--- a/application/pipeline-stacks/oncoanalyser/Dockerfile
+++ b/application/pipeline-stacks/oncoanalyser/Dockerfile
@@ -20,7 +20,7 @@ ARG DOCKER_CE_VERSION="23.0.1-1"
 ARG DOCKER_COMPOSE_VERSION="2.16.0-1"
 
 # Pipeline GH URL and branch/tag
-ARG PIPELINE_GITHUB_REF="pipeline5-v5.33"
+ARG PIPELINE_GITHUB_REF="v0.1.0"
 ARG PIPELINE_GITHUB_REPO_URL="https://github.com/scwatts/oncoanalyser.git"
 
 # Configure Conda

--- a/application/pipeline-stacks/sash/Dockerfile
+++ b/application/pipeline-stacks/sash/Dockerfile
@@ -20,7 +20,7 @@ ARG DOCKER_COMPOSE_VERSION="2.16.0-1"
 
 # Pipeline GH URL and branch/tag
 ARG PIPELINE_GITHUB_REPO_URL="https://github.com/scwatts/sash.git"
-ARG PIPELINE_GITHUB_REF="main"
+ARG PIPELINE_GITHUB_REF="v0.1.0"
 
 # Configure Conda
 RUN \

--- a/application/pipeline-stacks/sash/Dockerfile
+++ b/application/pipeline-stacks/sash/Dockerfile
@@ -20,7 +20,7 @@ ARG DOCKER_COMPOSE_VERSION="2.16.0-1"
 
 # Pipeline GH URL and branch/tag
 ARG PIPELINE_GITHUB_REPO_URL="https://github.com/scwatts/sash.git"
-ARG PIPELINE_GITHUB_REF="v0.1.0"
+ARG PIPELINE_GITHUB_REF="v0.1.1"
 
 # Configure Conda
 RUN \

--- a/application/pipeline-stacks/star-align-nf/Dockerfile
+++ b/application/pipeline-stacks/star-align-nf/Dockerfile
@@ -21,7 +21,7 @@ ARG DOCKER_COMPOSE_VERSION="2.16.0-1"
 
 # Pipeline GH URL and branch/tag
 ARG PIPELINE_GITHUB_REPO_URL="https://github.com/scwatts/star-align-nf.git"
-ARG PIPELINE_GITHUB_REF="main"
+ARG PIPELINE_GITHUB_REF="v0.1.0"
 
 # Configure Conda
 RUN \


### PR DESCRIPTION
- pipeline source GH repos used in this stack now use version release tags 
- switch from latest commit to specific release tags in Dockerfiles