### PR TITLE
Configure resource ramping for oncoanalyser

### DIFF
--- a/application/base-pipeline-stack.ts
+++ b/application/base-pipeline-stack.ts
@@ -123,7 +123,18 @@ const batchComputeTask: IBatchComputeData[] = [
       'c5d.4xlarge',
       'c6id.4xlarge',
     ],
-    // NOTE(SW): allow up to 16 concurrent jobs
+    // Allow up to 16 concurrent jobs
+    maxvCpus: 256,
+  },
+
+  {
+    name: '16cpu_128gb',
+    costModel: ComputeResourceType.SPOT,
+    instances: [
+      'r5d.4xlarge',
+      'r6id.4xlarge',
+    ],
+    // Allow up to 16 concurrent jobs
     maxvCpus: 256,
   },
 

--- a/application/pipeline-stacks/oncoanalyser/assets/nextflow_aws.template.config
+++ b/application/pipeline-stacks/oncoanalyser/assets/nextflow_aws.template.config
@@ -55,21 +55,30 @@ process {
   }
 
   withName: 'SVPREP_(?:TUMOR|NORMAL)' {
-    queue = 'nextflow-task-16cpu_32gb-spot'
-    cpus = 16
-    memory = 30.GB
+    errorStrategy = 'retry'
+    maxRetries = 2
+
+    queue =  { task.attempt == 1 ? 'nextflow-task-16cpu_32gb-spot' : 'nextflow-task-16cpu_128gb-spot' }
+    cpus =   { task.attempt == 1 ? 16                              : 8                                }
+    memory = { task.attempt == 1 ? 30.GB                           : 122.GB                           }
   }
 
   withName: '.*:GRIDSS_SVPREP_CALLING:(PREPROCESS|ASSEMBLE|CALL)' {
-    queue = 'nextflow-task-16cpu_32gb-spot'
-    cpus = 16
-    memory = 30.GB
+    errorStrategy = 'retry'
+    maxRetries = 2
+
+    queue =  { task.attempt == 1 ? 'nextflow-task-16cpu_32gb-spot' : 'nextflow-task-16cpu_128gb-spot' }
+    cpus =   { task.attempt == 1 ? 16                              : 8                                }
+    memory = { task.attempt == 1 ? 30.GB                           : 122.GB                           }
   }
 
   withName: '.*:GRIDSS_SVPREP_CALLING:DEPTH_ANNOTATOR' {
-    queue = 'nextflow-task-16cpu_32gb-spot'
-    cpus = 16
-    memory = 30.GB
+    errorStrategy = 'retry'
+    maxRetries = 2
+
+    queue =  { task.attempt == 1 ? 'nextflow-task-16cpu_32gb-spot' : 'nextflow-task-16cpu_128gb-spot' }
+    cpus =   { task.attempt == 1 ? 16                              : 8                                }
+    memory = { task.attempt == 1 ? 30.GB                           : 122.GB                           }
   }
 
   withName: '.*:GRIPSS_FILTERING:(?:GERMLINE|SOMATIC)' {
@@ -111,9 +120,12 @@ process {
   }
 
   withName: 'PURPLE' {
-    queue = 'nextflow-task-4cpu_32gb-spot'
-    cpus = 4
-    memory = 30.GB
+    errorStrategy = 'retry'
+    maxRetries = 2
+
+    queue =  { task.attempt == 1 ? 'nextflow-task-4cpu_32gb-spot' : 'nextflow-task-8cpu_64gb-spot' }
+    cpus =   { task.attempt == 1 ? 4                              : 8                              }
+    memory = { task.attempt == 1 ? 30.GB                          : 60.GB                          }
   }
 
   withName: '.*:LINX_ANNOTATION:(?:GERMLINE|SOMATIC)' {


### PR DESCRIPTION
Background

* samples with many SVs can require far greater amounts of memory than typical samples
* rather than inefficiently over allocating memory for most samples, resource ramping is now used

Changes

* failed tasks are automatically retried with increased memory and reduced number of CPUs
* this is currently limited to a maximum of one retry per task
* a new queue is available specifically for memory ramping, `nextflow-task-16cpu_128gb-spot`
* ramping is applied only to oncoanalyser SvPrep, GRIDSS, and PURPLE processes