### PR TITLE
Adjust SvPrep process config

### DIFF
--- a/application/base-pipeline-stack.ts
+++ b/application/base-pipeline-stack.ts
@@ -128,6 +128,17 @@ const batchComputeTask: IBatchComputeData[] = [
   },
 
   {
+    name: '16cpu_64gb',
+    costModel: ComputeResourceType.ON_DEMAND,
+    instances: [
+      'm5d.4xlarge',
+      'm6id.4xlarge',
+    ],
+    // Allow up to 16 concurrent jobs
+    maxvCpus: 256,
+  },
+
+  {
     name: '16cpu_128gb',
     costModel: ComputeResourceType.ON_DEMAND,
     instances: [

--- a/application/pipeline-stacks/oncoanalyser/assets/nextflow_aws.template.config
+++ b/application/pipeline-stacks/oncoanalyser/assets/nextflow_aws.template.config
@@ -64,7 +64,7 @@ process {
   }
 
   withName: 'SVPREP_NORMAL' {
-    queue = nextflow-task-16cpu_32gb
+    queue = 'nextflow-task-16cpu_32gb'
     cpus = 16
     memory = 30.GB
   }

--- a/application/pipeline-stacks/oncoanalyser/assets/nextflow_aws.template.config
+++ b/application/pipeline-stacks/oncoanalyser/assets/nextflow_aws.template.config
@@ -54,13 +54,19 @@ process {
     memory = 30.GB
   }
 
-  withName: 'SVPREP_(?:TUMOR|NORMAL)' {
+  withName: 'SVPREP_TUMOR' {
     errorStrategy = 'retry'
     maxRetries = 1
 
-    queue =  { task.attempt == 1 ? 'nextflow-task-16cpu_32gb' : 'nextflow-task-16cpu_128gb' }
+    queue =  { task.attempt == 1 ? 'nextflow-task-16cpu_64gb' : 'nextflow-task-16cpu_128gb' }
     cpus =   { task.attempt == 1 ? 16                         : 8                           }
-    memory = { task.attempt == 1 ? 30.GB                      : 122.GB                      }
+    memory = { task.attempt == 1 ? 60.GB                      : 122.GB                      }
+  }
+
+  withName: 'SVPREP_NORMAL' {
+    queue = nextflow-task-16cpu_32gb
+    cpus = 16
+    memory = 30.GB
   }
 
   withName: '.*:GRIDSS_SVPREP_CALLING:(PREPROCESS|ASSEMBLE|CALL)' {
@@ -76,9 +82,9 @@ process {
     errorStrategy = 'retry'
     maxRetries = 1
 
-    queue =  { task.attempt == 1 ? 'nextflow-task-16cpu_32gb' : 'nextflow-task-16cpu_128gb' }
+    queue =  { task.attempt == 1 ? 'nextflow-task-16cpu_64gb' : 'nextflow-task-16cpu_128gb' }
     cpus =   { task.attempt == 1 ? 16                         : 8                           }
-    memory = { task.attempt == 1 ? 30.GB                      : 122.GB                      }
+    memory = { task.attempt == 1 ? 60.GB                      : 122.GB                      }
   }
 
   withName: '.*:GRIPSS_FILTERING:(?:GERMLINE|SOMATIC)' {


### PR DESCRIPTION
- default to 16 vCPUs and 60 GB memory for SvPrep (tumor) and Depth Annotator
- add new nextflow-task-16cpu_64gb queue
- revert SvPrep (normal) to original config