### PR TITLE
Disable FusionFS for sash

### DIFF
--- a/application/application-stack.ts
+++ b/application/application-stack.ts
@@ -69,6 +69,7 @@ export class ApplicationStack extends Stack {
     const pipelineStack = new OncoanalyserStack(this, 'OncoanalyserStack', {
       ...args,
       pipelineVersionTag: stackSettings.versionTag,
+      fusionFs: stackSettings.fusionFs,
       nfBucketName: s3Data.get('nfBucketName')!,
       nfPrefixTemp: s3Data.get('nfPrefixTemp')!,
       nfPrefixOutput: s3Data.get('nfPrefixOutput')!,
@@ -86,6 +87,7 @@ export class ApplicationStack extends Stack {
     const pipelineStack = new StarAlignNfStack(this, 'SashStack', {
       ...args,
       pipelineVersionTag: stackSettings.versionTag,
+      fusionFs: stackSettings.fusionFs,
       nfBucketName: s3Data.get('nfBucketName')!,
       nfPrefixTemp: s3Data.get('nfPrefixTemp')!,
       nfPrefixOutput: s3Data.get('nfPrefixOutput')!,
@@ -103,6 +105,7 @@ export class ApplicationStack extends Stack {
     const pipelineStack = new StarAlignNfStack(this, 'StarAlignNfStack', {
       ...args,
       pipelineVersionTag: stackSettings.versionTag,
+      fusionFs: stackSettings.fusionFs,
       nfBucketName: s3Data.get('nfBucketName')!,
       nfPrefixTemp: s3Data.get('nfPrefixTemp')!,
       nfPrefixOutput: s3Data.get('nfPrefixOutput')!,

--- a/application/pipeline-stacks/oncoanalyser/assets/nextflow_aws.template.config
+++ b/application/pipeline-stacks/oncoanalyser/assets/nextflow_aws.template.config
@@ -17,7 +17,7 @@ aws {
   }
 }
 
-// NOTE(SW): required for FusionFS v2.1 to run jobs locally and use permissions granted by IAM roles
+// NOTE(SW): required for Nextflow to run jobs locally and use permissions granted by IAM roles
 docker.runOptions = '--network host'
 
 params {

--- a/application/pipeline-stacks/sash/assets/nextflow_aws.template.config
+++ b/application/pipeline-stacks/sash/assets/nextflow_aws.template.config
@@ -2,14 +2,6 @@ plugins {
   id 'nf-amazon'
 }
 
-fusion {
-  enabled = true
-}
-
-wave {
-  enabled = true
-}
-
 aws {
   batch {
     jobRole = '__BATCH_INSTANCE_ROLE__'
@@ -17,20 +9,22 @@ aws {
   }
 }
 
-// NOTE(SW): required for FusionFS v2.1 to run jobs locally and use permissions granted by IAM roles
+// NOTE(SW): required for Nextflow to run jobs locally and use permissions granted by IAM roles
 docker.runOptions = '--network host'
 
 process {
   executor = 'awsbatch'
-  scratch = false
+  scratch = '/tmp/'
 
   // NOTE(SW): AWS Batch jobs can only run where there is allocatable memory present on the instances, and this amount
   // is never the total capacity since ECS reserves memory and the system also occpies several hundred MiB. See
   // https://docs.aws.amazon.com/batch/latest/userguide/memory-management.html
   // NOTE(SW): Anything less than a 2.GB buffer appears to prevent Batch jobs from running on target instances
 
+  // NOTE(SW): Nextflow v23.09.1-edge does not allow mixing Batch and local execution with non-local paths
+
   withName: 'BOLT_SMLV_SOMATIC_RESCUE' {
-    executor = 'local'
+    queue = 'nextflow-task-2cpu_16gb'
     cpus = 1
     memory = 12.GB
   }
@@ -42,7 +36,7 @@ process {
   }
 
   withName: 'BOLT_SMLV_SOMATIC_FILTER' {
-    executor = 'local'
+    queue = 'nextflow-task-2cpu_16gb'
     cpus = 1
     memory = 12.GB
   }
@@ -54,7 +48,7 @@ process {
   }
 
   withName: 'BOLT_SMLV_GERMLINE_PREPARE' {
-    executor = 'local'
+    queue = 'nextflow-task-2cpu_16gb'
     cpus = 1
     memory = 12.GB
   }
@@ -72,7 +66,7 @@ process {
   }
 
   withName: 'BOLT_SV_SOMATIC_PRIORITISE' {
-    executor = 'local'
+    queue = 'nextflow-task-2cpu_16gb'
     cpus = 1
     memory = 12.GB
   }
@@ -84,26 +78,26 @@ process {
   }
 
   withName: 'BOLT_OTHER_PURPLE_BAF_PLOT' {
-    executor = 'local'
+    queue = 'nextflow-task-2cpu_16gb'
     cpus = 1
     memory = 12.GB
   }
 
   withName: 'BOLT_OTHER_CANCER_REPORT' {
-    executor = 'local'
+    queue = 'nextflow-task-2cpu_16gb'
     cpus = 1
     memory = 12.GB
   }
 
   withName: 'BOLT_OTHER_MULTIQC_REPORT' {
-    executor = 'local'
+    queue = 'nextflow-task-2cpu_16gb'
     cpus = 1
     memory = 12.GB
   }
 
   withName: '.*:LINX_ANNOTATION:(?:GERMLINE|SOMATIC)' {
-    executor = 'local'
-    cpus = 1
+    queue = 'nextflow-task-2cpu_16gb'
+    cpus = 2
     memory = 12.GB
   }
 
@@ -114,14 +108,15 @@ process {
   }
 
   withName: '.*:LINX_PLOTTING:GPGR' {
-    executor = 'local'
+    queue = 'nextflow-task-2cpu_16gb'
     cpus = 1
     memory = 12.GB
   }
 
   withName: 'CUSTOM_DUMPSOFTWAREVERSIONS' {
-    executor = 'local'
+    queue = 'nextflow-task-2cpu_16gb'
     cpus = 1
     memory = 12.GB
   }
+
 }

--- a/application/pipeline-stacks/star-align-nf/assets/nextflow_aws.template.config
+++ b/application/pipeline-stacks/star-align-nf/assets/nextflow_aws.template.config
@@ -17,7 +17,7 @@ aws {
   }
 }
 
-// NOTE(SW): required for FusionFS v2.1 to run jobs locally and use permissions granted by IAM roles
+// NOTE(SW): required for Nextflow to run jobs locally and use permissions granted by IAM roles
 docker.runOptions = '--network host'
 
 process {

--- a/application/settings.ts
+++ b/application/settings.ts
@@ -81,7 +81,7 @@ export class Oncoanalyser extends Shared {
 
 export class Sash extends Shared {
 
-  readonly versionTag = "v0.1.7";
+  readonly versionTag = "v0.1.9";
 
   getSsmParameters() {
     return new Map<string, string>([

--- a/application/settings.ts
+++ b/application/settings.ts
@@ -1,5 +1,7 @@
 class Shared {
 
+  fusionFs = true;
+
   constructor(public envName: string, public workflowName: string) {};
 
   getNfBucket() {
@@ -82,6 +84,7 @@ export class Oncoanalyser extends Shared {
 export class Sash extends Shared {
 
   readonly versionTag = "v0.1.9";
+  readonly fusionFs = false;
 
   getSsmParameters() {
     return new Map<string, string>([


### PR DESCRIPTION
* Bump to sash v0.1.9
  * Includes bolt v0.1.6, which removes partial workaround for FusionFS and PCGR/vcfanno
  * New Docker images for non-FusionFS configuration (all include extra layer with AWS CLIv2)
* Adds `fusionFs` stack setting
  * Controls container volumes and mount points in Batch job definition
* Update sash Nextflow configuration to disable FusionFS and Wave
  * Set scratch directory as local NVMe SSD to avoid increasing EBS volume size