### PR TITLE
Disable FusionFS/Wave for oncoanalyser

### DIFF
--- a/application/base-pipeline-stack.ts
+++ b/application/base-pipeline-stack.ts
@@ -41,13 +41,11 @@ const batchComputePipeline: IBatchComputeData = {
   name: 'pipeline',
   costModel: ComputeResourceType.ON_DEMAND,
   instances: [
-   'r5dn.large',
+   'r5n.large',
   ],
 };
 
 const batchComputeTask: IBatchComputeData[] = [
-
-  // TODO(SW): if the on-demand queue is used, restrict to instances with SSD for Fusion
 
   {
     name: 'unrestricted',
@@ -59,31 +57,18 @@ const batchComputeTask: IBatchComputeData[] = [
     name: '2cpu_16gb',
     costModel: ComputeResourceType.ON_DEMAND,
     instances: [
-     'r5d.large',
-     'r5dn.large',
-     'r6id.large',
+     'r5.large',
+     'r5n.large',
+     'r6i.large',
     ],
   },
-
-  /*
-
-  {
-    name: '4cpu_8gb',
-    costModel: ComputeResourceType.ON_DEMAND,
-    instances: [
-     'c5.xlarge',
-     'c6i.xlarge',
-    ],
-  },
-
-  */
 
   {
     name: '4cpu_16gb',
     costModel: ComputeResourceType.ON_DEMAND,
     instances: [
-      'm5d.xlarge',
-      'm6id.xlarge',
+      'm5.xlarge',
+      'm6i.xlarge',
     ],
   },
 
@@ -91,9 +76,9 @@ const batchComputeTask: IBatchComputeData[] = [
     name: '4cpu_32gb',
     costModel: ComputeResourceType.ON_DEMAND,
     instances: [
-      'r5d.xlarge',
-      'r5dn.xlarge',
-      'r6id.xlarge',
+      'r5.xlarge',
+      'r5n.xlarge',
+      'r6i.xlarge',
     ],
   },
 
@@ -101,8 +86,8 @@ const batchComputeTask: IBatchComputeData[] = [
     name: '8cpu_32gb',
     costModel: ComputeResourceType.ON_DEMAND,
     instances: [
-      'm5d.2xlarge',
-      'm6id.2xlarge',
+      'm5.2xlarge',
+      'm6i.2xlarge',
     ],
   },
 
@@ -110,9 +95,9 @@ const batchComputeTask: IBatchComputeData[] = [
     name: '8cpu_64gb',
     costModel: ComputeResourceType.ON_DEMAND,
     instances: [
-      'r5d.2xlarge',
-      'r5dn.2xlarge',
-      'r6id.2xlarge',
+      'r5.2xlarge',
+      'r5n.2xlarge',
+      'r6i.2xlarge',
     ],
   },
 
@@ -120,8 +105,8 @@ const batchComputeTask: IBatchComputeData[] = [
     name: '16cpu_32gb',
     costModel: ComputeResourceType.ON_DEMAND,
     instances: [
-      'c5d.4xlarge',
-      'c6id.4xlarge',
+      'c5.4xlarge',
+      'c6i.4xlarge',
     ],
     // Allow up to 16 concurrent jobs
     maxvCpus: 256,
@@ -131,8 +116,8 @@ const batchComputeTask: IBatchComputeData[] = [
     name: '16cpu_64gb',
     costModel: ComputeResourceType.ON_DEMAND,
     instances: [
-      'm5d.4xlarge',
-      'm6id.4xlarge',
+      'm5.4xlarge',
+      'm6i.4xlarge',
     ],
     // Allow up to 16 concurrent jobs
     maxvCpus: 256,
@@ -142,26 +127,12 @@ const batchComputeTask: IBatchComputeData[] = [
     name: '16cpu_128gb',
     costModel: ComputeResourceType.ON_DEMAND,
     instances: [
-      'r5d.4xlarge',
-      'r6id.4xlarge',
+      'r5.4xlarge',
+      'r6i.4xlarge',
     ],
     // Allow up to 16 concurrent jobs
     maxvCpus: 256,
   },
-
-  /*
-
-  {
-    name: '16cpu_64gb',
-    costModel: ComputeResourceType.SPOT,
-    instances: [
-      'm4.4xlarge',
-      'm5.4xlarge',
-      'm6i.4xlarge',
-    ],
-  },
-
- */
 
 ];
 
@@ -257,29 +228,46 @@ export class BasePipelineStack extends Stack {
     // NOTE(SW): using UserData.addCommands does not render with a MIME block when passed to the
     // batch-alpha.ComputeEnvironment, which then results in an invalid compute environment
 
-    // NOTE(SW): using 777 mode for Fusion NVMe SSD mount since I'm not certain whether different Docker users will
-    // impact ability to access e.g. Docker containers can run as either be root or mamberuser in oncoanalyser but Batch
-    // might run with elevate privileges
+    // Required packages for Amazon Elastic Block Store Autoscale set in the Cloud Config block
 
-    const userData = UserData.custom(
+    // NOTE(SW): The AWS CLIv2 install must not clobber Docker paths otherwise they are mounted over
+
+    const userDataTask = UserData.custom(
 `MIME-Version: 1.0
 Content-Type: multipart/mixed; boundary="==MYBOUNDARY=="
+
+--==MYBOUNDARY==
+Content-Type: text/cloud-config; charset="us-ascii"
+
+packages:
+  - btrfs-progs
+  - git
+  - jq
+  - lvm2
+  - sed
+  - unzip
+  - wget
 
 --==MYBOUNDARY==
 Content-Type: text/x-shellscript; charset="us-ascii"
 
 #!/bin/bash
-mkdir -p /mnt/local_ephemeral/
-mkfs.ext4 /dev/nvme1n1
-mount /dev/nvme1n1 /mnt/local_ephemeral/
-chmod 777 /mnt/local_ephemeral/
+curl https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o /tmp/awscliv2.zip
+unzip -q /tmp/awscliv2.zip -d /tmp/
 
+/tmp/aws/install --install-dir /opt/awscliv2/aws-cli/ --bin-dir /opt/awscliv2/bin/
+ln -s /opt/awscliv2/bin/aws /usr/local/bin/
+
+git clone -b v2.4.7 https://github.com/awslabs/amazon-ebs-autoscale /tmp/amazon-ebs-autoscale/
+bash /tmp/amazon-ebs-autoscale/install.sh --initial-size 20
+
+rm -rf /tmp/awscliv2.zip /tmp/aws/ /tmp/amazon-ebs-autoscale/
 --==MYBOUNDARY==--`
     );
 
     return new LaunchTemplate(this, `${args.namespace}LaunchTemplate`, {
       launchTemplateName: `nextflow-${args.namespace.toLowerCase()}-launch-template`,
-      userData: userData,
+      userData: (args.namespace == 'BaseTask') ? userDataTask : undefined,
     });
   }
 

--- a/application/base-pipeline-stack.ts
+++ b/application/base-pipeline-stack.ts
@@ -347,4 +347,3 @@ rm -rf /tmp/awscliv2.zip /tmp/aws/ /tmp/amazon-ebs-autoscale/
   return [computeEnvironment, jobQueue];
   }
 }
-

--- a/application/base-pipeline-stack.ts
+++ b/application/base-pipeline-stack.ts
@@ -41,7 +41,7 @@ const batchComputePipeline: IBatchComputeData = {
   name: 'pipeline',
   costModel: ComputeResourceType.ON_DEMAND,
   instances: [
-   'r5n.large',
+   'r6i.large',
   ],
 };
 

--- a/application/base-roles.ts
+++ b/application/base-roles.ts
@@ -87,6 +87,9 @@ export function getRoleBatchInstanceTask(args: { context: Stack, workflowName: s
     ],
   });
 
+  // TODO(SW): restrict instances this applies to using a condition with some stack-specific value
+  // such as instance name (NextflowApplication*), instance profile (defined in stack) or some
+  // other tag. Some condition keys: ec2:Attribute/${n}, ec2:ResourceTag/${n}, ec2:InstanceProfile
   new Policy(args.context, `TaskPolicyEbsAutoScale-${args.workflowName}`, {
     roles: [roleTask],
     statements: [new PolicyStatement({

--- a/application/base-roles.ts
+++ b/application/base-roles.ts
@@ -75,7 +75,7 @@ export function createPipelineRoles(args: { context: Stack, workflowName: string
 }
 
 export function getRoleBatchInstanceTask(args: { context: Stack, workflowName: string }) {
-  return new Role(args.context, `TaskBatchInstanceRole-${args.workflowName}`, {
+  const roleTask = new Role(args.context, `TaskBatchInstanceRole-${args.workflowName}`, {
     assumedBy: new CompositePrincipal(
       new ServicePrincipal('ec2.amazonaws.com'),
       new ServicePrincipal('ecs-tasks.amazonaws.com'),
@@ -86,6 +86,26 @@ export function getRoleBatchInstanceTask(args: { context: Stack, workflowName: s
       ManagedPolicy.fromAwsManagedPolicyName('service-role/AmazonEC2ContainerServiceforEC2Role'),
     ],
   });
+
+  new Policy(args.context, `TaskPolicyEbsAutoScale-${args.workflowName}`, {
+    roles: [roleTask],
+    statements: [new PolicyStatement({
+      actions: [
+        'ec2:AttachVolume',
+        'ec2:CreateTags',
+        'ec2:CreateVolume',
+        'ec2:DeleteVolume',
+        'ec2:DescribeTags',
+        'ec2:DescribeVolumeAttribute',
+        'ec2:DescribeVolumeStatus',
+        'ec2:DescribeVolumes',
+        'ec2:ModifyInstanceAttribute',
+      ],
+      resources: ['*'],
+    })],
+  });
+
+  return roleTask;
 }
 
 export function getBaseBatchInstancePipelineRole(args: { context: Stack, workflowName: string, jobQueueArns: string[] }) {

--- a/application/pipeline-stacks/oncoanalyser/assets/nextflow_aws.template.config
+++ b/application/pipeline-stacks/oncoanalyser/assets/nextflow_aws.template.config
@@ -180,6 +180,8 @@ process {
   }
 
   withName: '.*:LILAC_CALLING:SLICEBAM' {
+    container = 'docker.io/scwatts/samtools:1.15.1--h1170115_0'
+
     queue = 'nextflow-task-4cpu_32gb'
     cpus = 4
     memory = 30.GB
@@ -216,6 +218,8 @@ process {
   }
 
   withName: 'SAMTOOLS_FLAGSTAT' {
+    container = 'docker.io/scwatts/samtools:1.16.1--h6899075_1'
+
     queue = 'nextflow-task-2cpu_16gb'
     cpus = 2
     memory = 14.GB

--- a/application/pipeline-stacks/oncoanalyser/assets/nextflow_aws.template.config
+++ b/application/pipeline-stacks/oncoanalyser/assets/nextflow_aws.template.config
@@ -141,7 +141,7 @@ process {
 
   withName: '.*:LINX_PLOTTING:GPGR' {
     queue = 'nextflow-task-2cpu_16gb'
-    cpus = 2
+    cpus = 1
     memory = 14.GB
   }
 
@@ -157,7 +157,7 @@ process {
 
   withName: 'CHORD' {
     queue = 'nextflow-task-2cpu_16gb'
-    cpus = 2
+    cpus = 1
     memory = 14.GB
   }
 
@@ -189,7 +189,7 @@ process {
 
   withName: 'SIGS' {
     queue = 'nextflow-task-2cpu_16gb'
-    cpus = 2
+    cpus = 1
     memory = 14.GB
   }
 
@@ -201,7 +201,7 @@ process {
 
   withName: 'VIRUSINTERPRETER' {
     queue = 'nextflow-task-2cpu_16gb'
-    cpus = 2
+    cpus = 1
     memory = 14.GB
   }
 
@@ -211,9 +211,9 @@ process {
     memory = 30.GB
   }
 
-  withName: 'CUPPA.*' {
+  withName: 'CUPPA' {
     queue = 'nextflow-task-2cpu_16gb'
-    cpus = 2
+    cpus = 1
     memory = 14.GB
   }
 
@@ -227,13 +227,13 @@ process {
 
   withName: 'ORANGE' {
     queue = 'nextflow-task-2cpu_16gb'
-    cpus = 2
+    cpus = 1
     memory = 14.GB
   }
 
   withName: 'CUSTOM_DUMPSOFTWAREVERSIONS' {
     queue = 'nextflow-task-2cpu_16gb'
-    cpus = 2
+    cpus = 1
     memory = 14.GB
   }
 }

--- a/application/pipeline-stacks/oncoanalyser/assets/nextflow_aws.template.config
+++ b/application/pipeline-stacks/oncoanalyser/assets/nextflow_aws.template.config
@@ -2,14 +2,6 @@ plugins {
   id 'nf-amazon'
 }
 
-fusion {
-  enabled = true
-}
-
-wave {
-  enabled = true
-}
-
 aws {
   batch {
     jobRole = '__BATCH_INSTANCE_ROLE__'
@@ -35,7 +27,7 @@ params {
 
 process {
   executor = 'awsbatch'
-  scratch = false
+  scratch = '/tmp/'
 
   // NOTE(SW): AWS Batch jobs can only run where there is allocatable memory present on the instances, and this amount
   // is never the total capacity since ECS reserves memory and the system also occpies several hundred MiB. See
@@ -43,18 +35,24 @@ process {
   // NOTE(SW): Anything less than a 2.GB buffer appears to prevent Batch jobs from running on target instances
 
   withName: 'AMBER' {
+    container = 'docker.io/scwatts/amber:3.9--3-aws'
+
     queue = 'nextflow-task-8cpu_32gb'
     cpus = 8
     memory = 30.GB
   }
 
   withName: 'COBALT' {
+    container = 'docker.io/scwatts/cobalt:1.15.2--0-aws'
+
     queue = 'nextflow-task-8cpu_32gb'
     cpus = 8
     memory = 30.GB
   }
 
   withName: 'SVPREP_TUMOR' {
+    container = 'docker.io/scwatts/svprep:1.2.2--0-aws'
+
     errorStrategy = 'retry'
     maxRetries = 1
 
@@ -64,12 +62,16 @@ process {
   }
 
   withName: 'SVPREP_NORMAL' {
+    container = 'docker.io/scwatts/svprep:1.2.2--0-aws'
+
     queue = 'nextflow-task-16cpu_32gb'
     cpus = 16
     memory = 30.GB
   }
 
   withName: '.*:GRIDSS_SVPREP_CALLING:(PREPROCESS|ASSEMBLE|CALL)' {
+    container = 'docker.io/scwatts/svprep:1.2.2--0-aws'
+
     errorStrategy = 'retry'
     maxRetries = 1
 
@@ -79,6 +81,8 @@ process {
   }
 
   withName: '.*:GRIDSS_SVPREP_CALLING:DEPTH_ANNOTATOR' {
+    container = 'docker.io/scwatts/gripss:2.3.5--0-aws'
+
     errorStrategy = 'retry'
     maxRetries = 1
 
@@ -88,30 +92,40 @@ process {
   }
 
   withName: '.*:GRIPSS_FILTERING:(?:GERMLINE|SOMATIC)' {
+    container = 'docker.io/scwatts/gripss:2.3.5--0-aws'
+
     queue = 'nextflow-task-4cpu_32gb'
     cpus = 4
     memory = 30.GB
   }
 
   withName: '.*:SAGE_CALLING:GERMLINE' {
+    container = 'docker.io/scwatts/sage:3.3.1--0-aws'
+
     queue = 'nextflow-task-4cpu_32gb'
     cpus = 4
     memory = 30.GB
   }
 
   withName: '.*:SAGE_CALLING:SOMATIC' {
+    container = 'docker.io/scwatts/sage:3.3.1--0-aws'
+
     queue = 'nextflow-task-16cpu_32gb'
     cpus = 16
     memory = 30.GB
   }
 
   withName: '.*:SAGE_APPEND:(?:GERMLINE|SOMATIC)' {
-    executor = 'local'
-    cpus = 1
-    memory = 12.GB
+    container = 'docker.io/scwatts/sage:3.3.1--0-aws'
+
+    queue = 'nextflow-task-2cpu_16gb'
+    cpus = 2
+    memory = 14.GB
   }
 
   withName: '.*:PAVE_ANNOTATION:GERMLINE' {
+    container = 'docker.io/scwatts/pave:1.5--0-aws'
+
     queue = 'nextflow-task-2cpu_16gb'
     cpus = 2
     memory = 14.GB
@@ -120,12 +134,16 @@ process {
   // NOTE(SW): PAVE somatic uses a significant amount of memory, runtime is usually less than 5-10 minutes
 
   withName: '.*:PAVE_ANNOTATION:SOMATIC' {
+    container = 'docker.io/scwatts/pave:1.5--0-aws'
+
     queue = 'nextflow-task-4cpu_32gb'
     cpus = 4
     memory = 30.GB
   }
 
   withName: 'PURPLE' {
+    container = 'docker.io/scwatts/purple:3.9.2--0-aws'
+
     errorStrategy = 'retry'
     maxRetries = 1
 
@@ -135,24 +153,32 @@ process {
   }
 
   withName: '.*:LINX_ANNOTATION:(?:GERMLINE|SOMATIC)' {
-    executor = 'local'
-    cpus = 1
-    memory = 12.GB
+    container = 'docker.io/scwatts/linx:1.24.1--0-aws'
+
+    queue = 'nextflow-task-2cpu_16gb'
+    cpus = 2
+    memory = 14.GB
   }
 
   withName: '.*:LINX_PLOTTING:VISUALISER' {
+    container = 'docker.io/scwatts/linx:1.24.1--0-aws'
+
     queue = 'nextflow-task-8cpu_32gb'
     cpus = 8
     memory = 30.GB
   }
 
   withName: '.*:LINX_PLOTTING:GPGR' {
-    executor = 'local'
-    cpus = 1
-    memory = 12.GB
+    container = 'docker.io/scwatts/gpgr:1.4.5-aws'
+
+    queue = 'nextflow-task-2cpu_16gb'
+    cpus = 2
+    memory = 14.GB
   }
 
   withName: 'BAMTOOLS' {
+    container = 'docker.io/scwatts/bamtools:1.1--0-aws'
+
 
     // TODO(SW): can use much less memory for this process; create new CPU queue or determine whether performance over fusion is good enough for nextflow-task-16cpu_32gb
 
@@ -163,80 +189,106 @@ process {
   }
 
   withName: 'CHORD' {
-    executor = 'local'
-    cpus = 1
-    memory = 12.GB
+    container = 'docker.io/scwatts/chord:2.00--0-aws'
+
+    queue = 'nextflow-task-2cpu_16gb'
+    cpus = 2
+    memory = 14.GB
   }
 
   withName: 'LILAC' {
+    container = 'docker.io/scwatts/lilac:1.5--0-aws'
+
     queue = 'nextflow-task-4cpu_32gb'
     cpus = 4
     memory = 30.GB
   }
 
   withName: '.*:LILAC_CALLING:EXTRACTCONTIG' {
+    container = 'docker.io/scwatts/custom-extract_and_index_contig:0.0.1--3-aws'
+
     queue = 'nextflow-task-4cpu_32gb'
     cpus = 4
     memory = 30.GB
   }
 
   withName: '.*:LILAC_CALLING:REALIGNREADS' {
+    container = 'docker.io/scwatts/custom-realign_reads_lilac:0.0.1--3-aws'
+
     queue = 'nextflow-task-4cpu_32gb'
     cpus = 4
     memory = 30.GB
   }
 
   withName: '.*:LILAC_CALLING:SLICEBAM' {
+    container = 'docker.io/scwatts/samtools:1.15.1--h1170115_0-aws'
+
     queue = 'nextflow-task-4cpu_32gb'
     cpus = 4
     memory = 30.GB
   }
 
   withName: 'SIGS' {
-    executor = 'local'
-    cpus = 1
-    memory = 12.GB
+    container = 'docker.io/scwatts/sigs:1.1--0-aws'
+
+    queue = 'nextflow-task-2cpu_16gb'
+    cpus = 2
+    memory = 14.GB
   }
 
   withName: 'VIRUSBREAKEND' {
+    container = 'docker.io/scwatts/gridss:2.13.2--3-aws'
+
     queue = 'nextflow-task-8cpu_64gb'
     cpus = 8
     memory = 60.GB
   }
 
   withName: 'VIRUSINTERPRETER' {
-    executor = 'local'
-    cpus = 1
-    memory = 12.GB
+    container = 'docker.io/scwatts/virus_interpreter:1.3--0-aws'
+
+    queue = 'nextflow-task-2cpu_16gb'
+    cpus = 2
+    memory = 14.GB
   }
 
   withName: 'ISOFOX' {
+    container = 'docker.io/scwatts/isofox:1.6.2--0-aws'
+
     queue = 'nextflow-task-8cpu_32gb'
     cpus = 8
     memory = 30.GB
   }
 
   withName: 'CUPPA.*' {
-    executor = 'local'
-    cpus = 1
-    memory = 12.GB
+    container = 'docker.io/scwatts/cuppa:1.8.1--0-aws'
+
+    queue = 'nextflow-task-2cpu_16gb'
+    cpus = 2
+    memory = 14.GB
   }
 
   withName: 'SAMTOOLS_FLAGSTAT' {
+    container = 'docker.io/scwatts/samtools:1.16.1--h6899075_1-aws'
+
     queue = 'nextflow-task-2cpu_16gb'
     cpus = 2
     memory = 14.GB
   }
 
   withName: 'ORANGE' {
-    executor = 'local'
-    cpus = 1
-    memory = 12.GB
+    container = 'docker.io/scwatts/orange:2.7.0--0-aws'
+
+    queue = 'nextflow-task-2cpu_16gb'
+    cpus = 2
+    memory = 14.GB
   }
 
   withName: 'CUSTOM_DUMPSOFTWAREVERSIONS' {
-    executor = 'local'
-    cpus = 1
-    memory = 12.GB
+    container = 'docker.io/scwatts/multiqc:1.11--pyhdfd78af_0-aws'
+
+    queue = 'nextflow-task-2cpu_16gb'
+    cpus = 2
+    memory = 14.GB
   }
 }

--- a/application/pipeline-stacks/oncoanalyser/assets/nextflow_aws.template.config
+++ b/application/pipeline-stacks/oncoanalyser/assets/nextflow_aws.template.config
@@ -5,7 +5,8 @@ plugins {
 aws {
   batch {
     jobRole = '__BATCH_INSTANCE_ROLE__'
-    volumes = '/mnt/local_ephemeral/:/tmp/'
+    cliPath = '/opt/awscliv2/bin/aws'
+    volumes = '/scratch'
   }
 }
 
@@ -27,7 +28,7 @@ params {
 
 process {
   executor = 'awsbatch'
-  scratch = '/tmp/'
+  scratch = '/scratch/'
 
   // NOTE(SW): AWS Batch jobs can only run where there is allocatable memory present on the instances, and this amount
   // is never the total capacity since ECS reserves memory and the system also occpies several hundred MiB. See
@@ -35,24 +36,18 @@ process {
   // NOTE(SW): Anything less than a 2.GB buffer appears to prevent Batch jobs from running on target instances
 
   withName: 'AMBER' {
-    container = 'docker.io/scwatts/amber:3.9--3-aws'
-
     queue = 'nextflow-task-8cpu_32gb'
     cpus = 8
     memory = 30.GB
   }
 
   withName: 'COBALT' {
-    container = 'docker.io/scwatts/cobalt:1.15.2--0-aws'
-
     queue = 'nextflow-task-8cpu_32gb'
     cpus = 8
     memory = 30.GB
   }
 
   withName: 'SVPREP_TUMOR' {
-    container = 'docker.io/scwatts/svprep:1.2.2--0-aws'
-
     errorStrategy = 'retry'
     maxRetries = 1
 
@@ -62,16 +57,12 @@ process {
   }
 
   withName: 'SVPREP_NORMAL' {
-    container = 'docker.io/scwatts/svprep:1.2.2--0-aws'
-
     queue = 'nextflow-task-16cpu_32gb'
     cpus = 16
     memory = 30.GB
   }
 
   withName: '.*:GRIDSS_SVPREP_CALLING:(PREPROCESS|ASSEMBLE|CALL)' {
-    container = 'docker.io/scwatts/svprep:1.2.2--0-aws'
-
     errorStrategy = 'retry'
     maxRetries = 1
 
@@ -81,8 +72,6 @@ process {
   }
 
   withName: '.*:GRIDSS_SVPREP_CALLING:DEPTH_ANNOTATOR' {
-    container = 'docker.io/scwatts/gripss:2.3.5--0-aws'
-
     errorStrategy = 'retry'
     maxRetries = 1
 
@@ -92,40 +81,30 @@ process {
   }
 
   withName: '.*:GRIPSS_FILTERING:(?:GERMLINE|SOMATIC)' {
-    container = 'docker.io/scwatts/gripss:2.3.5--0-aws'
-
     queue = 'nextflow-task-4cpu_32gb'
     cpus = 4
     memory = 30.GB
   }
 
   withName: '.*:SAGE_CALLING:GERMLINE' {
-    container = 'docker.io/scwatts/sage:3.3.1--0-aws'
-
     queue = 'nextflow-task-4cpu_32gb'
     cpus = 4
     memory = 30.GB
   }
 
   withName: '.*:SAGE_CALLING:SOMATIC' {
-    container = 'docker.io/scwatts/sage:3.3.1--0-aws'
-
     queue = 'nextflow-task-16cpu_32gb'
     cpus = 16
     memory = 30.GB
   }
 
   withName: '.*:SAGE_APPEND:(?:GERMLINE|SOMATIC)' {
-    container = 'docker.io/scwatts/sage:3.3.1--0-aws'
-
     queue = 'nextflow-task-2cpu_16gb'
     cpus = 2
     memory = 14.GB
   }
 
   withName: '.*:PAVE_ANNOTATION:GERMLINE' {
-    container = 'docker.io/scwatts/pave:1.5--0-aws'
-
     queue = 'nextflow-task-2cpu_16gb'
     cpus = 2
     memory = 14.GB
@@ -134,16 +113,12 @@ process {
   // NOTE(SW): PAVE somatic uses a significant amount of memory, runtime is usually less than 5-10 minutes
 
   withName: '.*:PAVE_ANNOTATION:SOMATIC' {
-    container = 'docker.io/scwatts/pave:1.5--0-aws'
-
     queue = 'nextflow-task-4cpu_32gb'
     cpus = 4
     memory = 30.GB
   }
 
   withName: 'PURPLE' {
-    container = 'docker.io/scwatts/purple:3.9.2--0-aws'
-
     errorStrategy = 'retry'
     maxRetries = 1
 
@@ -153,32 +128,24 @@ process {
   }
 
   withName: '.*:LINX_ANNOTATION:(?:GERMLINE|SOMATIC)' {
-    container = 'docker.io/scwatts/linx:1.24.1--0-aws'
-
     queue = 'nextflow-task-2cpu_16gb'
     cpus = 2
     memory = 14.GB
   }
 
   withName: '.*:LINX_PLOTTING:VISUALISER' {
-    container = 'docker.io/scwatts/linx:1.24.1--0-aws'
-
     queue = 'nextflow-task-8cpu_32gb'
     cpus = 8
     memory = 30.GB
   }
 
   withName: '.*:LINX_PLOTTING:GPGR' {
-    container = 'docker.io/scwatts/gpgr:1.4.5-aws'
-
     queue = 'nextflow-task-2cpu_16gb'
     cpus = 2
     memory = 14.GB
   }
 
   withName: 'BAMTOOLS' {
-    container = 'docker.io/scwatts/bamtools:1.1--0-aws'
-
 
     // TODO(SW): can use much less memory for this process; create new CPU queue or determine whether performance over fusion is good enough for nextflow-task-16cpu_32gb
 
@@ -189,104 +156,78 @@ process {
   }
 
   withName: 'CHORD' {
-    container = 'docker.io/scwatts/chord:2.00--0-aws'
-
     queue = 'nextflow-task-2cpu_16gb'
     cpus = 2
     memory = 14.GB
   }
 
   withName: 'LILAC' {
-    container = 'docker.io/scwatts/lilac:1.5--0-aws'
-
     queue = 'nextflow-task-4cpu_32gb'
     cpus = 4
     memory = 30.GB
   }
 
   withName: '.*:LILAC_CALLING:EXTRACTCONTIG' {
-    container = 'docker.io/scwatts/custom-extract_and_index_contig:0.0.1--3-aws'
-
     queue = 'nextflow-task-4cpu_32gb'
     cpus = 4
     memory = 30.GB
   }
 
   withName: '.*:LILAC_CALLING:REALIGNREADS' {
-    container = 'docker.io/scwatts/custom-realign_reads_lilac:0.0.1--3-aws'
-
     queue = 'nextflow-task-4cpu_32gb'
     cpus = 4
     memory = 30.GB
   }
 
   withName: '.*:LILAC_CALLING:SLICEBAM' {
-    container = 'docker.io/scwatts/samtools:1.15.1--h1170115_0-aws'
-
     queue = 'nextflow-task-4cpu_32gb'
     cpus = 4
     memory = 30.GB
   }
 
   withName: 'SIGS' {
-    container = 'docker.io/scwatts/sigs:1.1--0-aws'
-
     queue = 'nextflow-task-2cpu_16gb'
     cpus = 2
     memory = 14.GB
   }
 
   withName: 'VIRUSBREAKEND' {
-    container = 'docker.io/scwatts/gridss:2.13.2--3-aws'
-
     queue = 'nextflow-task-8cpu_64gb'
     cpus = 8
     memory = 60.GB
   }
 
   withName: 'VIRUSINTERPRETER' {
-    container = 'docker.io/scwatts/virus_interpreter:1.3--0-aws'
-
     queue = 'nextflow-task-2cpu_16gb'
     cpus = 2
     memory = 14.GB
   }
 
   withName: 'ISOFOX' {
-    container = 'docker.io/scwatts/isofox:1.6.2--0-aws'
-
     queue = 'nextflow-task-8cpu_32gb'
     cpus = 8
     memory = 30.GB
   }
 
   withName: 'CUPPA.*' {
-    container = 'docker.io/scwatts/cuppa:1.8.1--0-aws'
-
     queue = 'nextflow-task-2cpu_16gb'
     cpus = 2
     memory = 14.GB
   }
 
   withName: 'SAMTOOLS_FLAGSTAT' {
-    container = 'docker.io/scwatts/samtools:1.16.1--h6899075_1-aws'
-
     queue = 'nextflow-task-2cpu_16gb'
     cpus = 2
     memory = 14.GB
   }
 
   withName: 'ORANGE' {
-    container = 'docker.io/scwatts/orange:2.7.0--0-aws'
-
     queue = 'nextflow-task-2cpu_16gb'
     cpus = 2
     memory = 14.GB
   }
 
   withName: 'CUSTOM_DUMPSOFTWAREVERSIONS' {
-    container = 'docker.io/scwatts/multiqc:1.11--pyhdfd78af_0-aws'
-
     queue = 'nextflow-task-2cpu_16gb'
     cpus = 2
     memory = 14.GB

--- a/application/pipeline-stacks/oncoanalyser/assets/nextflow_aws.template.config
+++ b/application/pipeline-stacks/oncoanalyser/assets/nextflow_aws.template.config
@@ -10,9 +10,6 @@ aws {
   }
 }
 
-// NOTE(SW): required for Nextflow to run jobs locally and use permissions granted by IAM roles
-docker.runOptions = '--network host'
-
 params {
   genomes {
     GRCh38_umccr {
@@ -236,4 +233,5 @@ process {
     cpus = 1
     memory = 14.GB
   }
+
 }


### PR DESCRIPTION
- Disabled FusionFS/Wave for oncoanalyser
- Made AWS CLIv2 available at instance-level via launch template rather than through modified Docker images
  - Wave was previously including AWS CLIv2 (and FusionFS) as extra image layers at runtime
- Switched to EC2 instances without local SSD storage, now using EBS storage only
- Included [Amazon Elastic Block Store Autoscale](https://github.com/awslabs/amazon-ebs-autoscale) in all instances
- Provided two EBS storage mountpoints
  - System (default): 30 GB for Docker images and temp files
  - Task scratch: 20 GB at launch with EBS autoscale incrementing in ~100 GB blocks