### PR TITLE
Increase initial EBS volume size

### DIFF
--- a/application/base-pipeline-stack.ts
+++ b/application/base-pipeline-stack.ts
@@ -262,7 +262,7 @@ unzip -q /tmp/awscliv2.zip -d /tmp/
 ln -s /opt/awscliv2/bin/aws /usr/local/bin/
 
 git clone -b v2.4.7 https://github.com/awslabs/amazon-ebs-autoscale /tmp/amazon-ebs-autoscale/
-bash /tmp/amazon-ebs-autoscale/install.sh --initial-size 30
+bash /tmp/amazon-ebs-autoscale/install.sh
 
 rm -rf /tmp/awscliv2.zip /tmp/aws/ /tmp/amazon-ebs-autoscale/
 --==BOUNDARY==--`

--- a/application/base-pipeline-stack.ts
+++ b/application/base-pipeline-stack.ts
@@ -262,7 +262,7 @@ unzip -q /tmp/awscliv2.zip -d /tmp/
 ln -s /opt/awscliv2/bin/aws /usr/local/bin/
 
 git clone -b v2.4.7 https://github.com/awslabs/amazon-ebs-autoscale /tmp/amazon-ebs-autoscale/
-bash /tmp/amazon-ebs-autoscale/install.sh --initial-size 20
+bash /tmp/amazon-ebs-autoscale/install.sh --initial-size 30
 
 rm -rf /tmp/awscliv2.zip /tmp/aws/ /tmp/amazon-ebs-autoscale/
 --==BOUNDARY==--`


### PR DESCRIPTION
#### Background

* in the absence of FusionFS, I'm currently using EBS autoscale to increase available scratch space at runtime
* the default scale-up threshold of 50% and initial 20 GB EBS volume doesn't provide a sufficient buffer in all cases
* e.g. a resource-ramped SvPrep Depth Annotator tasks run out of EBS space before it can be scaled
  * possibly related to higher instance memory size; larger memory buffer being dumped to disk too quickly
* observed in prod for SBJ04367, reproduced in dev

#### Changes

* increase initial volume to default 200 GB to give an effective buffer size of 100 GB

#### Other notes

* an increase to 30 GB resolved the issue described above for SBJ04367 resource-ramped SvPrep Depth Annotator task
  * however, the error retriggered in subsequent runs at same point with 30 GB and 50 GB initial volume sizes