### PR TITLE
Increase GRIDSS assembly default time limit

### DIFF
--- a/application/pipeline-stacks/oncoanalyser/assets/nextflow_aws.template.config
+++ b/application/pipeline-stacks/oncoanalyser/assets/nextflow_aws.template.config
@@ -59,15 +59,21 @@ process {
     memory = 30.GB
   }
 
-  withName: '.*:GRIDSS_SVPREP_CALLING:(PREPROCESS|ASSEMBLE|CALL)' {
+  withName: '.*:GRIDSS_SVPREP_CALLING:ASSEMBLE' {
     errorStrategy = 'retry'
     maxRetries = 1
 
     time = 12.h
 
     queue =  { task.attempt == 1 ? 'nextflow-task-16cpu_32gb' : 'nextflow-task-16cpu_128gb' }
-    cpus =   { task.attempt == 1 ? 16                         : 8                           }
+    cpus = 16
     memory = { task.attempt == 1 ? 30.GB                      : 122.GB                      }
+  }
+
+  withName: '.*:GRIDSS_SVPREP_CALLING:(PREPROCESS|CALL)' {
+    queue = 'nextflow-task-16cpu_32gb'
+    cpus = 16
+    memory = 30.GB
   }
 
   withName: '.*:GRIDSS_SVPREP_CALLING:DEPTH_ANNOTATOR' {

--- a/application/pipeline-stacks/oncoanalyser/assets/nextflow_aws.template.config
+++ b/application/pipeline-stacks/oncoanalyser/assets/nextflow_aws.template.config
@@ -63,6 +63,8 @@ process {
     errorStrategy = 'retry'
     maxRetries = 1
 
+    time = 12.h
+
     queue =  { task.attempt == 1 ? 'nextflow-task-16cpu_32gb' : 'nextflow-task-16cpu_128gb' }
     cpus =   { task.attempt == 1 ? 16                         : 8                           }
     memory = { task.attempt == 1 ? 30.GB                      : 122.GB                      }


### PR DESCRIPTION
#### Background

* the SBJ03026/L2201887 GRIDSS assembly task exceeded the default 8 hour time limit, causing it to fail
* the task was automatically retried with an extended 16 hour time limit, which succeeded
* in the failed first attempt, the task reached the final step of mapping breakend assembly contigs back to the ref genome
* I expect the task needed less than 1-2 hours to finish

#### Changes

* increased default time limit for GRIDSS assembly tasks from 8 hours to 12 hours
* separated GRIDSS assembly task retries and avoid decreasing CPU count on retry