### PR TITLE
Infer oncoanalyser output subdirectory from base pipeline directory

### DIFF
--- a/application/pipeline-stacks/oncoanalyser/lambda_functions/batch_job_submission/lambda_code.py
+++ b/application/pipeline-stacks/oncoanalyser/lambda_functions/batch_job_submission/lambda_code.py
@@ -182,7 +182,7 @@ def get_job_command(event):
         command_components.append(f'--existing_wgs_dir {get_wgs_existing_dir(event)}')
     elif event["mode"] == 'wgts_existing_wts':
         command_components.extend(command_components_wgts)
-        command_components.append(f'--existing_wts_dir {get_wts_existing_dir(event)]}')
+        command_components.append(f'--existing_wts_dir {get_wts_existing_dir(event)}')
     elif event["mode"] == 'wgts_existing_both':
         command_components.extend(command_components_wgts)
         command_components.append(f'--existing_wgs_dir {get_wgs_existing_dir(event)}')
@@ -194,11 +194,11 @@ def get_job_command(event):
 
 
 def get_wgs_existing_dir(event):
-    return pathlib.Path(event['existing_wgs_dir']) / f'{event["subject_id"]}_{event["tumor_wgs_sample_id"]}'
+    return event['existing_wgs_dir'].rstrip('/') + f'/{event["subject_id"]}_{event["tumor_wgs_sample_id"]}/'
 
 
 def get_wts_existing_dir(event):
-    return pathlib.Path(event['existing_wts_dir']) / f'{event["subject_id"]}_{event["tumor_wts_sample_id"]}'
+    return event['existing_wts_dir'].rstrip('/') + f'/{event["subject_id"]}_{event["tumor_wts_sample_id"]}/'
 
 
 def validate_event_data(event):

--- a/application/pipeline-stacks/oncoanalyser/lambda_functions/batch_job_submission/lambda_code.py
+++ b/application/pipeline-stacks/oncoanalyser/lambda_functions/batch_job_submission/lambda_code.py
@@ -31,8 +31,8 @@ def main(event, context):
         "normal_wgs_sample_id": "PRJ230003",
         "normal_wgs_library_id": "L2300003",
         "normal_wgs_bam": "gds://production/analysis_data/SBJ00001/wgs_tumor_normal/20230515zyxwvuts/L2300001_L2300002_dragen_somatic/PRJ230003_normal.bam",
-        "existing_wgs_dir": "s3://org.umccr.data.oncoanalyser/analysis_data/SBJ00001/oncoanalyser/20230515asdfghjk/wgs/L2300001__L2300003/SBJ00001_PRJ230001/",
-        "existing_wts_dir": "s3://org.umccr.data.oncoanalyser/analysis_data/SBJ00001/oncoanalyser/20230515zzxcvbnm/wts/L2300002/SBJ00001_PRJ230002/",
+        "existing_wgs_dir": "s3://org.umccr.data.oncoanalyser/analysis_data/SBJ00001/oncoanalyser/20230515asdfghjk/wgs/L2300001__L2300003/",
+        "existing_wts_dir": "s3://org.umccr.data.oncoanalyser/analysis_data/SBJ00001/oncoanalyser/20230515zzxcvbnm/wts/L2300002/",
     }
 
     :params dict event: Event payload
@@ -179,18 +179,26 @@ def get_job_command(event):
         command_components.extend(command_components_wgts)
     elif event["mode"] == 'wgts_existing_wgs':
         command_components.extend(command_components_wgts)
-        command_components.append(f'--existing_wgs_dir {event["existing_wgs_dir"]}')
+        command_components.append(f'--existing_wgs_dir {get_wgs_existing_dir(event)}')
     elif event["mode"] == 'wgts_existing_wts':
         command_components.extend(command_components_wgts)
-        command_components.append(f'--existing_wts_dir {event["existing_wts_dir"]}')
+        command_components.append(f'--existing_wts_dir {get_wts_existing_dir(event)]}')
     elif event["mode"] == 'wgts_existing_both':
         command_components.extend(command_components_wgts)
-        command_components.append(f'--existing_wgs_dir {event["existing_wgs_dir"]}')
-        command_components.append(f'--existing_wts_dir {event["existing_wts_dir"]}')
+        command_components.append(f'--existing_wgs_dir {get_wgs_existing_dir(event)}')
+        command_components.append(f'--existing_wts_dir {get_wts_existing_dir(event)}')
     else:
         assert False
 
     return ['bash', '-o', 'pipefail', '-c', ' '.join(command_components)]
+
+
+def get_wgs_existing_dir(event):
+    return pathlib.Path(event['existing_wgs_dir']) / f'{event["subject_id"]}_{event["tumor_wgs_sample_id"]}'
+
+
+def get_wts_existing_dir(event):
+    return pathlib.Path(event['existing_wts_dir']) / f'{event["subject_id"]}_{event["tumor_wts_sample_id"]}'
 
 
 def validate_event_data(event):

--- a/application/pipeline-stacks/sash/assets/run.sh
+++ b/application/pipeline-stacks/sash/assets/run.sh
@@ -65,15 +65,15 @@ while [ $# -gt 0 ]; do
     ;;
 
     --dragen_somatic_dir)
-      dragen_somatic_dir="$2"
+      dragen_somatic_dir="${2%/}"
       shift 1
     ;;
     --dragen_germline_dir)
-      dragen_germline_dir="$2"
+      dragen_germline_dir="${2%/}"
       shift 1
     ;;
     --oncoanalyser_dir)
-      oncoanalyser_dir="$2"
+      oncoanalyser_dir="${2%/}"
       shift 1
     ;;
 
@@ -363,7 +363,7 @@ for fp_name in ${input_file_args}; do
   if [[ ${fp} =~ ^gds://.* ]]; then
     input_fps[${fp_name}]=$(stage_gds_fp "${fp}")
   else
-    input_fps[${fp_name}]=${fp}
+    input_fps[${fp_name}]=${fp%}/
   fi
 done
 

--- a/application/pipeline-stacks/sash/lambda_functions/batch_job_submission/lambda_code.py
+++ b/application/pipeline-stacks/sash/lambda_functions/batch_job_submission/lambda_code.py
@@ -27,7 +27,7 @@ def main(event, context):
         "normal_library_id": "L2300002",
         "dragen_somatic_dir": "gds://production/analysis_data/SBJ00001/wgs_tumor_normal/20230515zyxwvuts/L2300001_L2300002/",
         "dragen_germline_dir": "gds://production/analysis_data/SBJ00001/wgs_tumor_normal/20230515zyxwvuts/L2300002_dragen_germline/",
-        "oncoanalyser_dir": "s3://org.umccr.data.oncoanalyser/analysis_data/SBJ00001/oncoanalyser/20230518poiuytre/wgs/L2300001__L2300002/SBJ00001_PRJ230001/"
+        "oncoanalyser_dir": "s3://org.umccr.data.oncoanalyser/analysis_data/SBJ00001/oncoanalyser/20230518poiuytre/wgs/L2300001__L2300002/"
     }
 
     :params dict event: Event payload
@@ -128,6 +128,8 @@ def get_job_command(event):
     output_scratch_dir = get_output_scratch_dir(event['subject_id'], event['portal_run_id'])
     output_staging_dir = get_output_staging_dir(event['subject_id'], event['portal_run_id'])
 
+    oncoanalyser_dir = pathlib.Path(event['oncoanalyser_dir']) / f'{event["subject_id"]}_{event["tumor_sample_id"]}'
+
     command_components = [
         './assets/run.sh',
         f'--subject_id {event["subject_id"]}',
@@ -137,7 +139,7 @@ def get_job_command(event):
         f'--normal_library_id {event["normal_library_id"]}',
         f'--dragen_somatic_dir {event["dragen_somatic_dir"]}',
         f'--dragen_germline_dir {event["dragen_germline_dir"]}',
-        f'--oncoanalyser_dir {event["oncoanalyser_dir"]}',
+        f'--oncoanalyser_dir {oncoanalyser_dir}',
         f'--output_results_dir {output_results_dir}',
         f'--output_staging_dir {output_staging_dir}',
         f'--output_scratch_dir {output_scratch_dir}',

--- a/application/pipeline-stacks/sash/lambda_functions/batch_job_submission/lambda_code.py
+++ b/application/pipeline-stacks/sash/lambda_functions/batch_job_submission/lambda_code.py
@@ -128,7 +128,7 @@ def get_job_command(event):
     output_scratch_dir = get_output_scratch_dir(event['subject_id'], event['portal_run_id'])
     output_staging_dir = get_output_staging_dir(event['subject_id'], event['portal_run_id'])
 
-    oncoanalyser_dir = pathlib.Path(event['oncoanalyser_dir']) / f'{event["subject_id"]}_{event["tumor_sample_id"]}'
+    oncoanalyser_dir = event['oncoanalyser_dir'].rstrip('/') + f'/{event["subject_id"]}_{event["tumor_sample_id"]}/'
 
     command_components = [
         './assets/run.sh',


### PR DESCRIPTION
**Background**

* the portal orchestrator is only aware of the base oncoanalyser pipeline output directory
* however, the Nextflow stack currently expects the subdirectory containing only oncoanalyser outputs, e.g.:

```text
Expected: s3://umccr-temp-dev/SBJ00001/oncoanalyser/202310207abcdefg/wgs/L2300001__L2300002/SBJ00001_MDX230001/
Provided: s3://umccr-temp-dev/SBJ00001/oncoanalyser/202310207abcdefg/wgs/L2300001__L2300002/
```

* since the portal orchestrator is not directly given info wrt the required subdir, this difference should be resolved here

**Changes**

* required input directory inferred from base oncoanalyser pipeline output directory
* additionally, enforced trailing slashes on directories present in the sash samplesheet