### PR TITLE
Use fixed GRIDSS image for VIRUSBreakend

### DIFF
--- a/application/pipeline-stacks/oncoanalyser/assets/nextflow_aws.template.config
+++ b/application/pipeline-stacks/oncoanalyser/assets/nextflow_aws.template.config
@@ -212,6 +212,12 @@ process {
   }
 
   withName: 'VIRUSBREAKEND' {
+
+    // NOTE(SW): this is a temporary fix to resolve issues related to missing
+    // RM Dfam database and should be removed once following PR is merged and a
+    // new release made: https://github.com/nf-core/oncoanalyser/pull/12.
+    container = 'docker.io/scwatts/gridss:2.13.2--1'
+
     queue = 'nextflow-task-ondemand-8cpu_64gb-nvme_ssd'
     cpus = 8
     memory = 60.GB


### PR DESCRIPTION
- replace slow BusyBox grep with GNU grep
- restore missing Dfam database required by RepeatMasker