### PR TITLE
Update STAR Docker image in star-align-nf

### DIFF
--- a/application/pipeline-stacks/star-align-nf/assets/nextflow_aws.template.config
+++ b/application/pipeline-stacks/star-align-nf/assets/nextflow_aws.template.config
@@ -34,6 +34,9 @@ process {
   }
 
   withName: 'STAR' {
+    // NOTE(SW): Batch/ECS instances unable to pull quay.io/biocontainers/star:2.7.3a--0 without error; fixed in next star-align-nf release
+    container = 'docker.io/scwatts/star:2.7.3a--1'
+
     queue = 'nextflow-task-ondemand-8cpu_64gb-nvme_ssd'
     cpus = 8
     memory = 60.GB


### PR DESCRIPTION
- Batch/ECS EC2 instances are now unable to pull `quay.io/biocontainers/star:2.7.3a--0` without error
- appears to only impact Batch/ECS EC2 instances; I can pull locally and on manually spun-up EC2 instances via NF/CLI
- error is resolved by using rebuilt STAR 2.7.3a Docker image hosted on Docker Hub and configuring STAR process to use
- `star-align-nf` will include this change by default on next release