### PR TITLE
Apply optimisations for oncoanalyser processes

### DIFF
--- a/application/pipeline-stacks/oncoanalyser/assets/nextflow_aws.template.config
+++ b/application/pipeline-stacks/oncoanalyser/assets/nextflow_aws.template.config
@@ -57,8 +57,8 @@ process {
   }
 
   withName: 'BWAMEM2_ALIGN' {
-    queue = 'nextflow-task-ondemand-16cpu_64gb-nvme_ssd'
-    cpus = 16
+    queue = 'nextflow-task-ondemand-32cpu_64gb-nvme_ssd'
+    cpus = 32
     memory = 60.GB
   }
 

--- a/application/pipeline-stacks/oncoanalyser/assets/nextflow_aws.template.config
+++ b/application/pipeline-stacks/oncoanalyser/assets/nextflow_aws.template.config
@@ -63,8 +63,8 @@ process {
   }
 
   withName: 'MARKDUPS' {
-    queue = 'nextflow-task-ondemand-32cpu_128gb-nvme_ssd'
-    cpus = 32
+    queue = 'nextflow-task-ondemand-16cpu_128gb-nvme_ssd'
+    cpus = 16
     memory = 120.GB
   }
 

--- a/application/pipeline-stacks/oncoanalyser/assets/nextflow_aws.template.config
+++ b/application/pipeline-stacks/oncoanalyser/assets/nextflow_aws.template.config
@@ -19,7 +19,7 @@ aws {
 
 params {
 
-  max_fastq_records = 30000000
+  max_fastq_records = 250000000
 
   genomes {
     GRCh38_umccr {

--- a/application/shared/batch-queues.ts
+++ b/application/shared/batch-queues.ts
@@ -117,13 +117,4 @@ export const taskQueues: IQueueData[] = [
     maxvCpus: 2048,
   },
 
-  {
-    name: '32cpu_128gb',
-    instances: new Map([
-      ['standard', ['m5a.8xlarge', 'm6a.8xlarge']],
-      ['nvme_ssd', ['m5d.8xlarge', 'm6id.8xlarge']],
-    ]),
-    maxvCpus: 256,
-  },
-
 ];

--- a/application/shared/batch-queues.ts
+++ b/application/shared/batch-queues.ts
@@ -109,6 +109,15 @@ export const taskQueues: IQueueData[] = [
   },
 
   {
+    name: '32cpu_64gb',
+    instances: new Map([
+      ['standard', ['c5a.8xlarge', 'c6a.8xlarge']],
+      ['nvme_ssd', ['c5ad.8xlarge', 'c6id.8xlarge']],
+    ]),
+    maxvCpus: 2048,
+  },
+
+  {
     name: '32cpu_128gb',
     instances: new Map([
       ['standard', ['m5a.8xlarge', 'm6a.8xlarge']],


### PR DESCRIPTION
- increase size of DNA FASTQs splits
- create a 32 CPU / 64 GB memory queue and place bwa-mem2 jobs on it
- run MarkDups jobs on the 16 CPU / 128 GB memory queue
- remove the 32 CPU / 128 GB memory queue