### PR TITLE
Bump sash 0.6.0

### DIFF
--- a/application/pipeline-stacks/common.ts
+++ b/application/pipeline-stacks/common.ts
@@ -11,7 +11,7 @@ import * as iam from 'aws-cdk-lib/aws-iam'
 import * as lambda from 'aws-cdk-lib/aws-lambda'
 import * as s3 from 'aws-cdk-lib/aws-s3';
 import * as ssm from 'aws-cdk-lib/aws-ssm';
-import { AWS_ENV_STG } from '../../deployment/settings-umccr';
+
 import * as ecrDeployment from 'cdk-ecr-deployment';
 
 import * as baseRoles from '../shared/base-roles';
@@ -51,7 +51,7 @@ export class PipelineStack extends cdk.Stack {
 
     // Create Docker image and deploy
     const dockerStack = new DockerImageBuildStack(this, `DockerImageBuildStack-${props.workflowName}`, {
-      env: AWS_ENV_STG,
+      env: props.envBuild,
       workflowName: props.workflowName,
       gitReference: props.pipelineVersionTag,
       dockerTag: props.dockerTag,

--- a/application/pipeline-stacks/common.ts
+++ b/application/pipeline-stacks/common.ts
@@ -11,7 +11,7 @@ import * as iam from 'aws-cdk-lib/aws-iam'
 import * as lambda from 'aws-cdk-lib/aws-lambda'
 import * as s3 from 'aws-cdk-lib/aws-s3';
 import * as ssm from 'aws-cdk-lib/aws-ssm';
-
+import { AWS_ENV_STG } from '../../deployment/settings-umccr';
 import * as ecrDeployment from 'cdk-ecr-deployment';
 
 import * as baseRoles from '../shared/base-roles';
@@ -51,7 +51,7 @@ export class PipelineStack extends cdk.Stack {
 
     // Create Docker image and deploy
     const dockerStack = new DockerImageBuildStack(this, `DockerImageBuildStack-${props.workflowName}`, {
-      env: props.envBuild,
+      env: AWS_ENV_STG,
       workflowName: props.workflowName,
       gitReference: props.pipelineVersionTag,
       dockerTag: props.dockerTag,

--- a/application/pipeline-stacks/common.ts
+++ b/application/pipeline-stacks/common.ts
@@ -198,6 +198,7 @@ export class DockerImageBuildStack extends cdk.Stack {
     const image = new ecrAssets.DockerImageAsset(this, `CDKDockerImage-${props.workflowName}`, {
       buildArgs: { 'PIPELINE_GITHUB_REF': props.gitReference },
       directory: path.join(__dirname, props.workflowName),
+      platform: ecrAssets.Platform.LINUX_AMD64,
     });
 
     const dockerDestBase = `${props.env.account}.dkr.ecr.${props.env.region}.amazonaws.com`;

--- a/application/pipeline-stacks/sash/Dockerfile
+++ b/application/pipeline-stacks/sash/Dockerfile
@@ -3,7 +3,7 @@ FROM docker.io/continuumio/miniconda3:23.10.0-1
 # Set package versions and other info
 # Generic
 ARG JQ_VERSION="1.6"
-ARG NEXTFLOW_VERSION="23.10.1"
+ARG NEXTFLOW_VERSION="25.04.3"
 ARG OPENJDK_VERSION="17.0.10"
 ARG PARALLEL_VERSION="20230322"
 ARG RCLONE_VERSION="1.62.2"

--- a/application/pipeline-stacks/sash/assets/nextflow_aws.template.config
+++ b/application/pipeline-stacks/sash/assets/nextflow_aws.template.config
@@ -133,11 +133,5 @@ process {
     cpus = 16
     memory = 60.GB
   }
-
-  withName: 'CUSTOM_DUMPSOFTWAREVERSIONS' {
-    queue = 'nextflow-task-ondemand-2cpu_16gb-ebs'
-    cpus = 2
-    memory = 14.GB
-  }
 }
 

--- a/application/pipeline-stacks/sash/assets/nextflow_aws.template.config
+++ b/application/pipeline-stacks/sash/assets/nextflow_aws.template.config
@@ -128,10 +128,16 @@ process {
     memory = 14.GB
   }
 
+  withName: 'ESVEE_CALL' {
+    queue = 'nextflow-task-ondemand-16cpu_64gb-ebs'
+    cpus = 16
+    memory = 60.GB
+  }
+
   withName: 'CUSTOM_DUMPSOFTWAREVERSIONS' {
     queue = 'nextflow-task-ondemand-2cpu_16gb-ebs'
     cpus = 2
     memory = 14.GB
   }
-
 }
+

--- a/application/pipeline-stacks/sash/assets/nextflow_aws.template.config
+++ b/application/pipeline-stacks/sash/assets/nextflow_aws.template.config
@@ -109,7 +109,7 @@ process {
     memory = 14.GB
   }
 
-  withName: '.*:LINX_PLOTTING:VISUALISER' {
+  withName: '.*:LINX_PLOTTING:LINX_VISUALISER' {
     errorStrategy = 'retry'
     maxRetries = 1
 
@@ -118,7 +118,7 @@ process {
     memory = 60.GB
   }
 
-  withName: '.*:LINX_PLOTTING:REPORT' {
+  withName: '.*:LINX_PLOTTING:LINXREPORT' {
     queue = 'nextflow-task-ondemand-2cpu_16gb-ebs'
     cpus = 2
     memory = 14.GB

--- a/application/pipeline-stacks/sash/assets/nextflow_aws.template.config
+++ b/application/pipeline-stacks/sash/assets/nextflow_aws.template.config
@@ -65,12 +65,6 @@ process {
     memory = 30.GB
   }
 
-  withName: '.*:GRIPSS_FILTERING:(?:GERMLINE|SOMATIC)' {
-    queue = 'nextflow-task-ondemand-4cpu_32gb-ebs'
-    cpus = 4
-    memory = 30.GB
-  }
-
   withName: 'BOLT_SV_SOMATIC_ANNOTATE' {
     queue = 'nextflow-task-ondemand-4cpu_32gb-ebs'
     cpus = 4

--- a/application/pipeline-stacks/sash/assets/nextflow_aws.template.config
+++ b/application/pipeline-stacks/sash/assets/nextflow_aws.template.config
@@ -7,6 +7,8 @@ aws {
     jobRole = '__BATCH_INSTANCE_ROLE__'
     cliPath = '/opt/awscliv2/bin/aws'
     volumes = '/scratch'
+    // NOTE(QC): Test using containerOptions to set LD_LIBRARY_PATH for zlibc.so.6 error
+    containerOptions = '--env LD_LIBRARY_PATH=/opt/awscliv2/aws-cli/v2/current/dist/'
   }
 }
 

--- a/application/pipeline-stacks/sash/assets/run.sh
+++ b/application/pipeline-stacks/sash/assets/run.sh
@@ -37,6 +37,7 @@ Options:
   --output_scratch_dir DIR      Output directory for scratch
 
   --resume_nextflow_dir FILE    Previous .nextflow/ directory used to resume a run (S3 URI)
+  --stub_run                    Enable stub run mode for testing workflow logic
 EOF
 }
 
@@ -100,6 +101,10 @@ while [ $# -gt 0 ]; do
     --resume_nextflow_dir)
       resume_nextflow_dir="${2%/}"
       shift 1
+    ;;
+
+    --stub_run)
+      stub_run="true"
     ;;
 
     -h|--help)
@@ -400,6 +405,9 @@ EOF
 nextflow_args=''
 if [[ -n "${resume_nextflow_dir:-}" ]]; then
   nextflow_args+=' -resume'
+fi
+if [[ "${stub_run:-}" == "true" ]]; then
+  nextflow_args+=' -stub'
 fi
 
 ## END NEXFLOW ARGS ##

--- a/application/settings.ts
+++ b/application/settings.ts
@@ -114,7 +114,7 @@ export class Oncoanalyser extends Shared {
 
 
 export class Sash extends Shared {
-  readonly versionTag = 'v0.6.0'
+  readonly versionTag = 'v0.6.0-dev'
 
   getSsmParameters() {
     return new Map<string, string>([

--- a/application/settings.ts
+++ b/application/settings.ts
@@ -114,7 +114,7 @@ export class Oncoanalyser extends Shared {
 
 
 export class Sash extends Shared {
-  readonly versionTag = 'v0.5.0'
+  readonly versionTag = 'v0.6.0'
 
   getSsmParameters() {
     return new Map<string, string>([

--- a/application/settings.ts
+++ b/application/settings.ts
@@ -114,7 +114,7 @@ export class Oncoanalyser extends Shared {
 
 
 export class Sash extends Shared {
-  readonly versionTag = 'v0.6.0-dev'
+  readonly versionTag = 'v0.6.0'
 
   getSsmParameters() {
     return new Map<string, string>([


### PR DESCRIPTION
- Add queu for eSVee call 
- Add `--stub_run` option in `run.sh`
- Add `containerOptions` in config to addressing a potential `zlibc.so.6` error.
- Upgrade sash version `v0.5.0` to `v0.6.0`
- Remove deprecated config `GRIPSS_FILTERING` and `CUSTOM_DUMPSOFTWAREVERSIONS`
- Specify container platform `linux/amd64`

