### PR TITLE
Disable Nextflow Fusion

### DIFF
--- a/application/pipeline-stacks/oncoanalyser/assets/nextflow_aws.template.config
+++ b/application/pipeline-stacks/oncoanalyser/assets/nextflow_aws.template.config
@@ -1,19 +1,8 @@
-plugins {
-  id 'nf-amazon'
-}
-
-fusion {
-  enabled = true
-}
-
-wave {
-  enabled = true
-}
-
 aws {
   batch {
     jobRole = '__BATCH_INSTANCE_ROLE__'
-    volumes = '/mnt/local_ephemeral/:/tmp/'
+    cliPath = '/opt/awscliv2/bin/aws'
+    volumes = '/scratch'
   }
 }
 
@@ -36,7 +25,7 @@ params {
 
 process {
   executor = 'awsbatch'
-  scratch = false
+  scratch = '/scratch/'
 
   // NOTE(SW): using docker.runOptions in 23.10.01 causes `--network host` to be included twice, triggering an error in Docker
   containerOptions = '--network host'
@@ -51,55 +40,55 @@ process {
   }
 
   withName: 'FASTP' {
-    queue = 'nextflow-task-ondemand-16cpu_32gb-nvme_ssd'
+    queue = 'nextflow-task-ondemand-16cpu_32gb-ebs'
     cpus = 16
     memory = 30.GB
   }
 
   withName: 'BWAMEM2_ALIGN' {
-    queue = 'nextflow-task-ondemand-32cpu_64gb-nvme_ssd'
+    queue = 'nextflow-task-ondemand-32cpu_64gb-ebs'
     cpus = 32
     memory = 60.GB
   }
 
   withName: 'MARKDUPS' {
-    queue = 'nextflow-task-ondemand-16cpu_128gb-nvme_ssd'
+    queue = 'nextflow-task-ondemand-16cpu_128gb-ebs'
     cpus = 16
     memory = 120.GB
   }
 
   withName: 'STAR_ALIGN' {
-    queue = 'nextflow-task-ondemand-8cpu_64gb-nvme_ssd'
+    queue = 'nextflow-task-ondemand-8cpu_64gb-ebs'
     cpus = 8
     memory = 60.GB
   }
 
   withName: 'SAMTOOLS_SORT' {
-    queue = 'nextflow-task-ondemand-8cpu_32gb-nvme_ssd'
+    queue = 'nextflow-task-ondemand-8cpu_32gb-ebs'
     cpus = 8
     memory = 30.GB
   }
 
   withName: 'SAMBAMBA_MERGE' {
-    queue = 'nextflow-task-ondemand-8cpu_32gb-nvme_ssd'
+    queue = 'nextflow-task-ondemand-8cpu_32gb-ebs'
     cpus = 8
     memory = 30.GB
   }
 
   withName: 'GATK4_MARKDUPLICATES' {
-    queue = 'nextflow-task-ondemand-8cpu_32gb-nvme_ssd'
+    queue = 'nextflow-task-ondemand-8cpu_32gb-ebs'
     cpus = 8
     memory = 30.GB
   }
 
   withName: 'AMBER' {
-    queue = 'nextflow-task-ondemand-8cpu_32gb-nvme_ssd'
+    queue = 'nextflow-task-ondemand-8cpu_32gb-ebs'
     cpus = 8
     memory = 30.GB
   }
 
   withName: 'COBALT' {
-    queue = 'nextflow-task-ondemand-8cpu_32gb-nvme_ssd'
+    queue = 'nextflow-task-ondemand-8cpu_32gb-ebs'
     cpus = 8
     memory = 30.GB
   }
@@ -108,13 +97,13 @@ process {
     errorStrategy = 'retry'
     maxRetries = 1
 
-    queue =  { task.attempt == 1 ? 'nextflow-task-ondemand-16cpu_64gb-nvme_ssd' : 'nextflow-task-ondemand-16cpu_128gb-nvme_ssd' }
-    cpus =   { task.attempt == 1 ? 16                                           : 8                                             }
-    memory = { task.attempt == 1 ? 60.GB                                        : 122.GB                                        }
+    queue =  { task.attempt == 1 ? 'nextflow-task-ondemand-16cpu_64gb-ebs' : 'nextflow-task-ondemand-16cpu_128gb-ebs' }
+    cpus =   { task.attempt == 1 ? 16                                      : 8                                        }
+    memory = { task.attempt == 1 ? 60.GB                                   : 122.GB                                   }
   }
 
   withName: 'SVPREP_NORMAL' {
-    queue = 'nextflow-task-ondemand-16cpu_32gb-nvme_ssd'
+    queue = 'nextflow-task-ondemand-16cpu_32gb-ebs'
     cpus = 16
     memory = 30.GB
   }
@@ -125,13 +114,13 @@ process {
 
     time = 12.h
 
-    queue =  { task.attempt == 1 ? 'nextflow-task-ondemand-16cpu_32gb-nvme_ssd' : 'nextflow-task-ondemand-16cpu_128gb-nvme_ssd' }
+    queue =  { task.attempt == 1 ? 'nextflow-task-ondemand-16cpu_32gb-ebs' : 'nextflow-task-ondemand-16cpu_128gb-ebs' }
     cpus = 16
-    memory = { task.attempt == 1 ? 30.GB                                        : 122.GB                                        }
+    memory = { task.attempt == 1 ? 30.GB                                   : 122.GB                                   }
   }
 
   withName: '.*:GRIDSS_SVPREP_CALLING:(PREPROCESS|CALL)' {
-    queue = 'nextflow-task-ondemand-16cpu_32gb-nvme_ssd'
+    queue = 'nextflow-task-ondemand-16cpu_32gb-ebs'
     cpus = 16
     memory = 30.GB
   }
@@ -140,37 +129,37 @@ process {
     errorStrategy = 'retry'
     maxRetries = 1
 
-    queue =  { task.attempt == 1 ? 'nextflow-task-ondemand-16cpu_64gb-nvme_ssd' : 'nextflow-task-ondemand-16cpu_128gb-nvme_ssd' }
-    cpus =   { task.attempt == 1 ? 16                                           : 8                                             }
-    memory = { task.attempt == 1 ? 60.GB                                        : 122.GB                                        }
+    queue =  { task.attempt == 1 ? 'nextflow-task-ondemand-16cpu_64gb-ebs' : 'nextflow-task-ondemand-16cpu_128gb-ebs' }
+    cpus =   { task.attempt == 1 ? 16                                      : 8                                        }
+    memory = { task.attempt == 1 ? 60.GB                                   : 122.GB                                   }
   }
 
   withName: '.*:GRIPSS_FILTERING:(?:GERMLINE|SOMATIC)' {
-    queue = 'nextflow-task-ondemand-4cpu_32gb-nvme_ssd'
+    queue = 'nextflow-task-ondemand-4cpu_32gb-ebs'
     cpus = 4
     memory = 30.GB
   }
 
   withName: '.*:SAGE_CALLING:GERMLINE' {
-    queue = 'nextflow-task-ondemand-4cpu_32gb-nvme_ssd'
+    queue = 'nextflow-task-ondemand-4cpu_32gb-ebs'
     cpus = 4
     memory = 30.GB
   }
 
   withName: '.*:SAGE_CALLING:SOMATIC' {
-    queue = 'nextflow-task-ondemand-16cpu_32gb-nvme_ssd'
+    queue = 'nextflow-task-ondemand-16cpu_32gb-ebs'
     cpus = 16
     memory = 30.GB
   }
 
   withName: '.*:SAGE_APPEND:(?:GERMLINE|SOMATIC)' {
-    queue = 'nextflow-task-ondemand-2cpu_16gb-nvme_ssd'
+    queue = 'nextflow-task-ondemand-2cpu_16gb-ebs'
     cpus = 2
     memory = 14.GB
   }
 
   withName: '.*:PAVE_ANNOTATION:GERMLINE' {
-    queue = 'nextflow-task-ondemand-2cpu_16gb-nvme_ssd'
+    queue = 'nextflow-task-ondemand-2cpu_16gb-ebs'
     cpus = 2
     memory = 14.GB
   }
@@ -178,7 +167,7 @@ process {
   // NOTE(SW): PAVE somatic uses a significant amount of memory, runtime is usually less than 5-10 minutes
 
   withName: '.*:PAVE_ANNOTATION:SOMATIC' {
-    queue = 'nextflow-task-ondemand-4cpu_32gb-nvme_ssd'
+    queue = 'nextflow-task-ondemand-4cpu_32gb-ebs'
     cpus = 4
     memory = 30.GB
   }
@@ -187,9 +176,9 @@ process {
     errorStrategy = 'retry'
     maxRetries = 1
 
-    queue =  { task.attempt == 1 ? 'nextflow-task-ondemand-4cpu_32gb-nvme_ssd' : 'nextflow-task-ondemand-8cpu_64gb-nvme_ssd' }
-    cpus =   { task.attempt == 1 ? 4                                           : 8                                           }
-    memory = { task.attempt == 1 ? 30.GB                                       : 60.GB                                       }
+    queue =  { task.attempt == 1 ? 'nextflow-task-ondemand-4cpu_32gb-ebs' : 'nextflow-task-ondemand-8cpu_64gb-ebs' }
+    cpus =   { task.attempt == 1 ? 4                                      : 8                                      }
+    memory = { task.attempt == 1 ? 30.GB                                  : 60.GB                                  }
   }
 
   withName: '.*:LINX_ANNOTATION:(?:GERMLINE|SOMATIC)' {
@@ -202,7 +191,7 @@ process {
     errorStrategy = 'retry'
     maxRetries = 1
 
-    queue = 'nextflow-task-ondemand-8cpu_64gb-nvme_ssd'
+    queue = 'nextflow-task-ondemand-8cpu_64gb-ebs'
     cpus = 8
     memory = 60.GB
   }
@@ -217,7 +206,7 @@ process {
 
     // TODO(SW): can use much less memory for this process; create new CPU queue or determine whether performance over fusion is good enough for nextflow-task-16cpu_32gb
 
-    queue = 'nextflow-task-ondemand-8cpu_32gb-nvme_ssd'
+    queue = 'nextflow-task-ondemand-8cpu_32gb-ebs'
     cpus = 8
     memory = 30.GB
     time = 24.h
@@ -230,25 +219,25 @@ process {
   }
 
   withName: 'LILAC' {
-    queue = 'nextflow-task-ondemand-4cpu_32gb-nvme_ssd'
+    queue = 'nextflow-task-ondemand-4cpu_32gb-ebs'
     cpus = 4
     memory = 30.GB
   }
 
   withName: '.*:LILAC_CALLING:EXTRACTCONTIG' {
-    queue = 'nextflow-task-ondemand-4cpu_32gb-nvme_ssd'
+    queue = 'nextflow-task-ondemand-4cpu_32gb-ebs'
     cpus = 4
     memory = 30.GB
   }
 
   withName: '.*:LILAC_CALLING:REALIGNREADS' {
-    queue = 'nextflow-task-ondemand-4cpu_32gb-nvme_ssd'
+    queue = 'nextflow-task-ondemand-4cpu_32gb-ebs'
     cpus = 4
     memory = 30.GB
   }
 
   withName: '.*:LILAC_CALLING:SLICEBAM' {
-    queue = 'nextflow-task-ondemand-4cpu_32gb-nvme_ssd'
+    queue = 'nextflow-task-ondemand-4cpu_32gb-ebs'
     cpus = 4
     memory = 30.GB
   }
@@ -260,7 +249,7 @@ process {
   }
 
   withName: 'VIRUSBREAKEND' {
-    queue = 'nextflow-task-ondemand-8cpu_64gb-nvme_ssd'
+    queue = 'nextflow-task-ondemand-8cpu_64gb-ebs'
     cpus = 8
     memory = 60.GB
   }
@@ -272,7 +261,7 @@ process {
   }
 
   withName: 'ISOFOX' {
-    queue = 'nextflow-task-ondemand-8cpu_32gb-nvme_ssd'
+    queue = 'nextflow-task-ondemand-8cpu_32gb-ebs'
     cpus = 8
     memory = 30.GB
   }
@@ -284,7 +273,7 @@ process {
   }
 
   withName: 'SAMTOOLS_FLAGSTAT' {
-    queue = 'nextflow-task-ondemand-2cpu_16gb-nvme_ssd'
+    queue = 'nextflow-task-ondemand-2cpu_16gb-ebs'
     cpus = 2
     memory = 14.GB
   }

--- a/application/pipeline-stacks/oncoanalyser/assets/nextflow_aws.template.config
+++ b/application/pipeline-stacks/oncoanalyser/assets/nextflow_aws.template.config
@@ -27,8 +27,7 @@ process {
   executor = 'awsbatch'
   scratch = '/scratch/'
 
-  // NOTE(SW): using docker.runOptions in 23.10.01 causes `--network host` to be included twice, triggering an error in Docker
-  containerOptions = '--network host'
+  containerOptions = '--env LD_LIBRARY_PATH=/opt/awscliv2/aws-cli/v2/current/dist'
 
   resourceLabels = {
     return [

--- a/application/pipeline-stacks/oncoanalyser/assets/nextflow_aws.template.config
+++ b/application/pipeline-stacks/oncoanalyser/assets/nextflow_aws.template.config
@@ -182,9 +182,9 @@ process {
   }
 
   withName: '.*:LINX_ANNOTATION:(?:GERMLINE|SOMATIC)' {
-    executor = 'local'
-    cpus = 1
-    memory = 12.GB
+    queue = 'nextflow-task-ondemand-2cpu_16gb-ebs'
+    cpus = 2
+    memory = 14.GB
   }
 
   withName: '.*:LINX_PLOTTING:VISUALISER' {
@@ -197,9 +197,9 @@ process {
   }
 
   withName: '.*:LINX_PLOTTING:REPORT' {
-    executor = 'local'
-    cpus = 1
-    memory = 12.GB
+    queue = 'nextflow-task-ondemand-2cpu_16gb-ebs'
+    cpus = 2
+    memory = 14.GB
   }
 
   withName: 'BAMTOOLS' {
@@ -213,9 +213,9 @@ process {
   }
 
   withName: 'CHORD' {
-    executor = 'local'
-    cpus = 1
-    memory = 12.GB
+    queue = 'nextflow-task-ondemand-2cpu_16gb-ebs'
+    cpus = 2
+    memory = 14.GB
   }
 
   withName: 'LILAC' {
@@ -243,9 +243,9 @@ process {
   }
 
   withName: 'SIGS' {
-    executor = 'local'
-    cpus = 1
-    memory = 12.GB
+    queue = 'nextflow-task-ondemand-2cpu_16gb-ebs'
+    cpus = 2
+    memory = 14.GB
   }
 
   withName: 'VIRUSBREAKEND' {
@@ -255,9 +255,9 @@ process {
   }
 
   withName: 'VIRUSINTERPRETER' {
-    executor = 'local'
-    cpus = 1
-    memory = 12.GB
+    queue = 'nextflow-task-ondemand-2cpu_16gb-ebs'
+    cpus = 2
+    memory = 14.GB
   }
 
   withName: 'ISOFOX' {
@@ -267,9 +267,9 @@ process {
   }
 
   withName: 'CUPPA' {
-    executor = 'local'
-    cpus = 1
-    memory = 12.GB
+    queue = 'nextflow-task-ondemand-2cpu_16gb-ebs'
+    cpus = 2
+    memory = 14.GB
   }
 
   withName: 'SAMTOOLS_FLAGSTAT' {
@@ -279,15 +279,15 @@ process {
   }
 
   withName: 'ORANGE' {
-    executor = 'local'
-    cpus = 1
-    memory = 12.GB
+    queue = 'nextflow-task-ondemand-2cpu_16gb-ebs'
+    cpus = 2
+    memory = 14.GB
   }
 
   withName: 'CUSTOM_DUMPSOFTWAREVERSIONS' {
-    executor = 'local'
-    cpus = 1
-    memory = 12.GB
+    queue = 'nextflow-task-ondemand-2cpu_16gb-ebs'
+    cpus = 2
+    memory = 14.GB
   }
 
 }

--- a/application/pipeline-stacks/sash/assets/nextflow_aws.template.config
+++ b/application/pipeline-stacks/sash/assets/nextflow_aws.template.config
@@ -1,7 +1,3 @@
-plugins {
-  id 'nf-amazon'
-}
-
 aws {
   batch {
     jobRole = '__BATCH_INSTANCE_ROLE__'

--- a/application/pipeline-stacks/sash/assets/nextflow_aws.template.config
+++ b/application/pipeline-stacks/sash/assets/nextflow_aws.template.config
@@ -10,6 +10,8 @@ process {
   executor = 'awsbatch'
   scratch = '/scratch/'
 
+  containerOptions = '--env LD_LIBRARY_PATH=/opt/awscliv2/aws-cli/v2/current/dist'
+
   resourceLabels = {
     return [
       'Stack': 'NextflowStack',

--- a/application/pipeline-stacks/star-align-nf/assets/nextflow_aws.template.config
+++ b/application/pipeline-stacks/star-align-nf/assets/nextflow_aws.template.config
@@ -1,25 +1,14 @@
-plugins {
-  id 'nf-amazon'
-}
-
-fusion {
-  enabled = true
-}
-
-wave {
-  enabled = true
-}
-
 aws {
   batch {
     jobRole = '__BATCH_INSTANCE_ROLE__'
-    volumes = '/mnt/local_ephemeral/:/tmp/'
+    cliPath = '/opt/awscliv2/bin/aws'
+    volumes = '/scratch'
   }
 }
 
 process {
   executor = 'awsbatch'
-  scratch = false
+  scratch = '/scratch/'
 
   // NOTE(SW): using docker.runOptions in 23.10.01 causes `--network host` to be included twice, triggering an error in Docker
   containerOptions = '--network host'
@@ -37,19 +26,19 @@ process {
     // NOTE(SW): Batch/ECS instances unable to pull quay.io/biocontainers/star:2.7.3a--0 without error; fixed in next star-align-nf release
     container = 'docker.io/scwatts/star:2.7.3a--1'
 
-    queue = 'nextflow-task-ondemand-8cpu_64gb-nvme_ssd'
+    queue = 'nextflow-task-ondemand-8cpu_64gb-ebs'
     cpus = 8
     memory = 60.GB
   }
 
   withName: 'SAMTOOLS_SORT' {
-    queue = 'nextflow-task-ondemand-4cpu_16gb-nvme_ssd'
+    queue = 'nextflow-task-ondemand-4cpu_16gb-ebs'
     cpus = 4
     memory = 14.GB
   }
 
   withName: 'GATK4_MARKDUPLICATES' {
-    queue = 'nextflow-task-ondemand-2cpu_16gb-nvme_ssd'
+    queue = 'nextflow-task-ondemand-2cpu_16gb-ebs'
     cpus = 1
     memory = 14.GB
   }

--- a/application/pipeline-stacks/star-align-nf/assets/nextflow_aws.template.config
+++ b/application/pipeline-stacks/star-align-nf/assets/nextflow_aws.template.config
@@ -10,8 +10,7 @@ process {
   executor = 'awsbatch'
   scratch = '/scratch/'
 
-  // NOTE(SW): using docker.runOptions in 23.10.01 causes `--network host` to be included twice, triggering an error in Docker
-  containerOptions = '--network host'
+  containerOptions = '--env LD_LIBRARY_PATH=/opt/awscliv2/aws-cli/v2/current/dist'
 
   resourceLabels = {
     return [

--- a/application/pipeline-stacks/star-align-nf/assets/nextflow_aws.template.config
+++ b/application/pipeline-stacks/star-align-nf/assets/nextflow_aws.template.config
@@ -44,9 +44,9 @@ process {
   }
 
   withName: 'CUSTOM_DUMPSOFTWAREVERSIONS' {
-    executor = 'local'
-    cpus = 1
-    memory = 12.GB
+    queue = 'nextflow-task-ondemand-2cpu_16gb-ebs'
+    cpus = 2
+    memory = 14.GB
   }
 
 }

--- a/application/settings.ts
+++ b/application/settings.ts
@@ -9,7 +9,7 @@ export const taskQueueTypes = [
 
 export const taskInstanceStorageTypes = [
   constants.InstanceStorageType.EbsOnly,
-  constants.InstanceStorageType.NvmeSsdOnly,
+  //constants.InstanceStorageType.NvmeSsdOnly,
 ];
 
 export const maxvCpusDefault = 128;


### PR DESCRIPTION
- Seqera will be [enforcing Fusion licensing](https://docs.seqera.io/fusion/licensing) on June 30th
- while the free-tier is generous it is preferred not to risk exceeding this threshold
- additionally the use of Fusion would require Seqera account credentials
- this PR turns of Fusion in all pipelines and adjust configuration to use EBS-backed EC2 instances