### PR TITLE
Bump oncoanalyser 2.0.0 and sash 0.6.0, deactivate Nextflow Fusion

### DIFF
--- a/application/pipeline-stacks/common.ts
+++ b/application/pipeline-stacks/common.ts
@@ -11,7 +11,7 @@ import * as iam from 'aws-cdk-lib/aws-iam'
 import * as lambda from 'aws-cdk-lib/aws-lambda'
 import * as s3 from 'aws-cdk-lib/aws-s3';
 import * as ssm from 'aws-cdk-lib/aws-ssm';
-import { AWS_ENV_STG } from '../../deployment/settings-umccr';
+
 import * as ecrDeployment from 'cdk-ecr-deployment';
 
 import * as baseRoles from '../shared/base-roles';
@@ -51,7 +51,7 @@ export class PipelineStack extends cdk.Stack {
 
     // Create Docker image and deploy
     const dockerStack = new DockerImageBuildStack(this, `DockerImageBuildStack-${props.workflowName}`, {
-      env: AWS_ENV_STG,
+      env: props.envBuild,
       workflowName: props.workflowName,
       gitReference: props.pipelineVersionTag,
       dockerTag: props.dockerTag,

--- a/application/pipeline-stacks/common.ts
+++ b/application/pipeline-stacks/common.ts
@@ -11,7 +11,7 @@ import * as iam from 'aws-cdk-lib/aws-iam'
 import * as lambda from 'aws-cdk-lib/aws-lambda'
 import * as s3 from 'aws-cdk-lib/aws-s3';
 import * as ssm from 'aws-cdk-lib/aws-ssm';
-
+import { AWS_ENV_STG } from '../../deployment/settings-umccr';
 import * as ecrDeployment from 'cdk-ecr-deployment';
 
 import * as baseRoles from '../shared/base-roles';
@@ -51,7 +51,7 @@ export class PipelineStack extends cdk.Stack {
 
     // Create Docker image and deploy
     const dockerStack = new DockerImageBuildStack(this, `DockerImageBuildStack-${props.workflowName}`, {
-      env: props.envBuild,
+      env: AWS_ENV_STG,
       workflowName: props.workflowName,
       gitReference: props.pipelineVersionTag,
       dockerTag: props.dockerTag,

--- a/application/pipeline-stacks/common.ts
+++ b/application/pipeline-stacks/common.ts
@@ -198,6 +198,7 @@ export class DockerImageBuildStack extends cdk.Stack {
     const image = new ecrAssets.DockerImageAsset(this, `CDKDockerImage-${props.workflowName}`, {
       buildArgs: { 'PIPELINE_GITHUB_REF': props.gitReference },
       directory: path.join(__dirname, props.workflowName),
+      platform: ecrAssets.Platform.LINUX_AMD64,
     });
 
     const dockerDestBase = `${props.env.account}.dkr.ecr.${props.env.region}.amazonaws.com`;

--- a/application/pipeline-stacks/oncoanalyser/Dockerfile
+++ b/application/pipeline-stacks/oncoanalyser/Dockerfile
@@ -3,7 +3,7 @@ FROM docker.io/continuumio/miniconda3:23.10.0-1
 # Set package versions and other info
 # Generic
 ARG JQ_VERSION="1.7.1"
-ARG NEXTFLOW_VERSION="24.04.4"
+ARG NEXTFLOW_VERSION="24.10.1"
 ARG OPENJDK_VERSION="17.0.10"
 ARG PARALLEL_VERSION="20230322"
 ARG RCLONE_VERSION="1.62.2"

--- a/application/pipeline-stacks/oncoanalyser/assets/nextflow_aws.template.config
+++ b/application/pipeline-stacks/oncoanalyser/assets/nextflow_aws.template.config
@@ -26,6 +26,7 @@ params {
       fasta         = "__S3_GENOMES_DATA_PATH__/GRCh38_umccr/GRCh38_full_analysis_set_plus_decoy_hla.fa"
       fai           = "__S3_GENOMES_DATA_PATH__/GRCh38_umccr/samtools_index/1.16/GRCh38_full_analysis_set_plus_decoy_hla.fa.fai"
       dict          = "__S3_GENOMES_DATA_PATH__/GRCh38_umccr/samtools_index/1.16/GRCh38_full_analysis_set_plus_decoy_hla.fa.dict"
+      img           = "__S3_GENOMES_DATA_PATH__/GRCh38_umccr/bwa_index_image/0.7.17-r1188/GRCh38_full_analysis_set_plus_decoy_hla.fa.img"
       bwamem2_index = "__S3_GENOMES_DATA_PATH__/GRCh38_umccr/bwa-mem2_index/2.2.1/"
       gridss_index  = "__S3_GENOMES_DATA_PATH__/GRCh38_umccr/gridss_index/2.13.2/"
       star_index    = "__S3_GENOMES_DATA_PATH__/GRCh38_umccr/star_index/gencode_38/2.7.3a/"

--- a/application/pipeline-stacks/oncoanalyser/assets/nextflow_aws.template.config
+++ b/application/pipeline-stacks/oncoanalyser/assets/nextflow_aws.template.config
@@ -1,7 +1,3 @@
-plugins {
-  id 'nf-amazon'
-}
-
 fusion {
   enabled = true
 }
@@ -63,7 +59,7 @@ process {
     memory = 60.GB
   }
 
-  withName: 'MARKDUPS' {
+  withName: 'REDUX' {
     queue = 'nextflow-task-ondemand-16cpu_128gb-nvme_ssd'
     cpus = 16
     memory = 120.GB
@@ -105,7 +101,7 @@ process {
     memory = 30.GB
   }
 
-  withName: 'SVPREP_TUMOR' {
+  withName: 'ESVEE_PREP' {
     errorStrategy = 'retry'
     maxRetries = 1
 
@@ -114,30 +110,24 @@ process {
     memory = { task.attempt == 1 ? 60.GB                                        : 122.GB                                        }
   }
 
-  withName: 'SVPREP_NORMAL' {
-    queue = 'nextflow-task-ondemand-16cpu_32gb-nvme_ssd'
-    cpus = 16
-    memory = 30.GB
-  }
-
-  withName: '.*:GRIDSS_SVPREP_CALLING:ASSEMBLE' {
+  withName: 'ESVEE_ASSEMBLE' {
     errorStrategy = 'retry'
     maxRetries = 1
 
     time = 12.h
 
-    queue =  { task.attempt == 1 ? 'nextflow-task-ondemand-16cpu_32gb-nvme_ssd' : 'nextflow-task-ondemand-16cpu_128gb-nvme_ssd' }
+    queue =  { task.attempt == 1 ? 'nextflow-task-ondemand-16cpu_64gb-nvme_ssd' : 'nextflow-task-ondemand-16cpu_128gb-nvme_ssd' }
     cpus = 16
-    memory = { task.attempt == 1 ? 30.GB                                        : 122.GB                                        }
+    memory = { task.attempt == 1 ? 60.GB                                        : 122.GB                                        }
   }
 
-  withName: '.*:GRIDSS_SVPREP_CALLING:(PREPROCESS|CALL)' {
+  withName: 'ESVEE_CALL' {
     queue = 'nextflow-task-ondemand-16cpu_32gb-nvme_ssd'
     cpus = 16
     memory = 30.GB
   }
 
-  withName: '.*:GRIDSS_SVPREP_CALLING:DEPTH_ANNOTATOR' {
+  withName: 'ESVEE_DEPTH_ANNOTATOR' {
     errorStrategy = 'retry'
     maxRetries = 1
 
@@ -146,31 +136,25 @@ process {
     memory = { task.attempt == 1 ? 60.GB                                        : 122.GB                                        }
   }
 
-  withName: '.*:GRIPSS_FILTERING:(?:GERMLINE|SOMATIC)' {
+  withName: '.*:SAGE_CALLING:SAGE_GERMLINE' {
     queue = 'nextflow-task-ondemand-4cpu_32gb-nvme_ssd'
     cpus = 4
     memory = 30.GB
   }
 
-  withName: '.*:SAGE_CALLING:GERMLINE' {
-    queue = 'nextflow-task-ondemand-4cpu_32gb-nvme_ssd'
-    cpus = 4
-    memory = 30.GB
-  }
-
-  withName: '.*:SAGE_CALLING:SOMATIC' {
+  withName: '.*:SAGE_CALLING:SAGE_SOMATIC' {
     queue = 'nextflow-task-ondemand-16cpu_32gb-nvme_ssd'
     cpus = 16
     memory = 30.GB
   }
 
-  withName: '.*:SAGE_APPEND:(?:GERMLINE|SOMATIC)' {
+  withName: '.*:SAGE_APPEND:SAGE_APPEND_(?:GERMLINE|SOMATIC)' {
     queue = 'nextflow-task-ondemand-2cpu_16gb-nvme_ssd'
     cpus = 2
     memory = 14.GB
   }
 
-  withName: '.*:PAVE_ANNOTATION:GERMLINE' {
+  withName: '.*:PAVE_ANNOTATION:PAVE_GERMLINE' {
     queue = 'nextflow-task-ondemand-2cpu_16gb-nvme_ssd'
     cpus = 2
     memory = 14.GB
@@ -178,7 +162,7 @@ process {
 
   // NOTE(SW): PAVE somatic uses a significant amount of memory, runtime is usually less than 5-10 minutes
 
-  withName: '.*:PAVE_ANNOTATION:SOMATIC' {
+  withName: '.*:PAVE_ANNOTATION:PAVE_SOMATIC' {
     queue = 'nextflow-task-ondemand-4cpu_32gb-nvme_ssd'
     cpus = 4
     memory = 30.GB
@@ -193,13 +177,13 @@ process {
     memory = { task.attempt == 1 ? 30.GB                                       : 60.GB                                       }
   }
 
-  withName: '.*:LINX_ANNOTATION:(?:GERMLINE|SOMATIC)' {
+  withName: '.*:LINX_ANNOTATION:LINX_(?:GERMLINE|SOMATIC)' {
     executor = 'local'
     cpus = 1
     memory = 12.GB
   }
 
-  withName: '.*:LINX_PLOTTING:VISUALISER' {
+  withName: '.*:LINX_PLOTTING:LINX_VISUALISER' {
     errorStrategy = 'retry'
     maxRetries = 1
 
@@ -208,7 +192,7 @@ process {
     memory = 60.GB
   }
 
-  withName: '.*:LINX_PLOTTING:REPORT' {
+  withName: '.*:LINX_PLOTTING:LINXREPORT' {
     executor = 'local'
     cpus = 1
     memory = 12.GB
@@ -284,19 +268,7 @@ process {
     memory = 12.GB
   }
 
-  withName: 'SAMTOOLS_FLAGSTAT' {
-    queue = 'nextflow-task-ondemand-2cpu_16gb-nvme_ssd'
-    cpus = 2
-    memory = 14.GB
-  }
-
   withName: 'ORANGE' {
-    executor = 'local'
-    cpus = 1
-    memory = 12.GB
-  }
-
-  withName: 'CUSTOM_DUMPSOFTWAREVERSIONS' {
     executor = 'local'
     cpus = 1
     memory = 12.GB

--- a/application/pipeline-stacks/oncoanalyser/assets/nextflow_aws.template.config
+++ b/application/pipeline-stacks/oncoanalyser/assets/nextflow_aws.template.config
@@ -1,19 +1,8 @@
-plugins {
-  id 'nf-amazon'
-}
-
-fusion {
-  enabled = true
-}
-
-wave {
-  enabled = true
-}
-
 aws {
   batch {
     jobRole = '__BATCH_INSTANCE_ROLE__'
-    volumes = '/mnt/local_ephemeral/:/tmp/'
+    cliPath = '/opt/awscliv2/bin/aws'
+    volumes = '/scratch'
   }
 }
 
@@ -36,7 +25,7 @@ params {
 
 process {
   executor = 'awsbatch'
-  scratch = false
+  scratch = '/scratch/'
 
   // NOTE(SW): using docker.runOptions in 23.10.01 causes `--network host` to be included twice, triggering an error in Docker
   containerOptions = '--network host'
@@ -51,55 +40,55 @@ process {
   }
 
   withName: 'FASTP' {
-    queue = 'nextflow-task-ondemand-16cpu_32gb-nvme_ssd'
+    queue = 'nextflow-task-ondemand-16cpu_32gb-ebs'
     cpus = 16
     memory = 30.GB
   }
 
   withName: 'BWAMEM2_ALIGN' {
-    queue = 'nextflow-task-ondemand-32cpu_64gb-nvme_ssd'
+    queue = 'nextflow-task-ondemand-32cpu_64gb-ebs'
     cpus = 32
     memory = 60.GB
   }
 
   withName: 'MARKDUPS' {
-    queue = 'nextflow-task-ondemand-16cpu_128gb-nvme_ssd'
+    queue = 'nextflow-task-ondemand-16cpu_128gb-ebs'
     cpus = 16
     memory = 120.GB
   }
 
   withName: 'STAR_ALIGN' {
-    queue = 'nextflow-task-ondemand-8cpu_64gb-nvme_ssd'
+    queue = 'nextflow-task-ondemand-8cpu_64gb-ebs'
     cpus = 8
     memory = 60.GB
   }
 
   withName: 'SAMTOOLS_SORT' {
-    queue = 'nextflow-task-ondemand-8cpu_32gb-nvme_ssd'
+    queue = 'nextflow-task-ondemand-8cpu_32gb-ebs'
     cpus = 8
     memory = 30.GB
   }
 
   withName: 'SAMBAMBA_MERGE' {
-    queue = 'nextflow-task-ondemand-8cpu_32gb-nvme_ssd'
+    queue = 'nextflow-task-ondemand-8cpu_32gb-ebs'
     cpus = 8
     memory = 30.GB
   }
 
   withName: 'GATK4_MARKDUPLICATES' {
-    queue = 'nextflow-task-ondemand-8cpu_32gb-nvme_ssd'
+    queue = 'nextflow-task-ondemand-8cpu_32gb-ebs'
     cpus = 8
     memory = 30.GB
   }
 
   withName: 'AMBER' {
-    queue = 'nextflow-task-ondemand-8cpu_32gb-nvme_ssd'
+    queue = 'nextflow-task-ondemand-8cpu_32gb-ebs'
     cpus = 8
     memory = 30.GB
   }
 
   withName: 'COBALT' {
-    queue = 'nextflow-task-ondemand-8cpu_32gb-nvme_ssd'
+    queue = 'nextflow-task-ondemand-8cpu_32gb-ebs'
     cpus = 8
     memory = 30.GB
   }
@@ -108,13 +97,13 @@ process {
     errorStrategy = 'retry'
     maxRetries = 1
 
-    queue =  { task.attempt == 1 ? 'nextflow-task-ondemand-16cpu_64gb-nvme_ssd' : 'nextflow-task-ondemand-16cpu_128gb-nvme_ssd' }
-    cpus =   { task.attempt == 1 ? 16                                           : 8                                             }
-    memory = { task.attempt == 1 ? 60.GB                                        : 122.GB                                        }
+    queue =  { task.attempt == 1 ? 'nextflow-task-ondemand-16cpu_64gb-ebs' : 'nextflow-task-ondemand-16cpu_128gb-ebs' }
+    cpus =   { task.attempt == 1 ? 16                                      : 8                                        }
+    memory = { task.attempt == 1 ? 60.GB                                   : 122.GB                                   }
   }
 
   withName: 'SVPREP_NORMAL' {
-    queue = 'nextflow-task-ondemand-16cpu_32gb-nvme_ssd'
+    queue = 'nextflow-task-ondemand-16cpu_32gb-ebs'
     cpus = 16
     memory = 30.GB
   }
@@ -125,13 +114,13 @@ process {
 
     time = 12.h
 
-    queue =  { task.attempt == 1 ? 'nextflow-task-ondemand-16cpu_32gb-nvme_ssd' : 'nextflow-task-ondemand-16cpu_128gb-nvme_ssd' }
+    queue =  { task.attempt == 1 ? 'nextflow-task-ondemand-16cpu_32gb-ebs' : 'nextflow-task-ondemand-16cpu_128gb-ebs' }
     cpus = 16
-    memory = { task.attempt == 1 ? 30.GB                                        : 122.GB                                        }
+    memory = { task.attempt == 1 ? 30.GB                                   : 122.GB                                   }
   }
 
   withName: '.*:GRIDSS_SVPREP_CALLING:(PREPROCESS|CALL)' {
-    queue = 'nextflow-task-ondemand-16cpu_32gb-nvme_ssd'
+    queue = 'nextflow-task-ondemand-16cpu_32gb-ebs'
     cpus = 16
     memory = 30.GB
   }
@@ -140,37 +129,37 @@ process {
     errorStrategy = 'retry'
     maxRetries = 1
 
-    queue =  { task.attempt == 1 ? 'nextflow-task-ondemand-16cpu_64gb-nvme_ssd' : 'nextflow-task-ondemand-16cpu_128gb-nvme_ssd' }
-    cpus =   { task.attempt == 1 ? 16                                           : 8                                             }
-    memory = { task.attempt == 1 ? 60.GB                                        : 122.GB                                        }
+    queue =  { task.attempt == 1 ? 'nextflow-task-ondemand-16cpu_64gb-ebs' : 'nextflow-task-ondemand-16cpu_128gb-ebs' }
+    cpus =   { task.attempt == 1 ? 16                                      : 8                                        }
+    memory = { task.attempt == 1 ? 60.GB                                   : 122.GB                                   }
   }
 
   withName: '.*:GRIPSS_FILTERING:(?:GERMLINE|SOMATIC)' {
-    queue = 'nextflow-task-ondemand-4cpu_32gb-nvme_ssd'
+    queue = 'nextflow-task-ondemand-4cpu_32gb-ebs'
     cpus = 4
     memory = 30.GB
   }
 
   withName: '.*:SAGE_CALLING:GERMLINE' {
-    queue = 'nextflow-task-ondemand-4cpu_32gb-nvme_ssd'
+    queue = 'nextflow-task-ondemand-4cpu_32gb-ebs'
     cpus = 4
     memory = 30.GB
   }
 
   withName: '.*:SAGE_CALLING:SOMATIC' {
-    queue = 'nextflow-task-ondemand-16cpu_32gb-nvme_ssd'
+    queue = 'nextflow-task-ondemand-16cpu_32gb-ebs'
     cpus = 16
     memory = 30.GB
   }
 
   withName: '.*:SAGE_APPEND:(?:GERMLINE|SOMATIC)' {
-    queue = 'nextflow-task-ondemand-2cpu_16gb-nvme_ssd'
+    queue = 'nextflow-task-ondemand-2cpu_16gb-ebs'
     cpus = 2
     memory = 14.GB
   }
 
   withName: '.*:PAVE_ANNOTATION:GERMLINE' {
-    queue = 'nextflow-task-ondemand-2cpu_16gb-nvme_ssd'
+    queue = 'nextflow-task-ondemand-2cpu_16gb-ebs'
     cpus = 2
     memory = 14.GB
   }
@@ -178,7 +167,7 @@ process {
   // NOTE(SW): PAVE somatic uses a significant amount of memory, runtime is usually less than 5-10 minutes
 
   withName: '.*:PAVE_ANNOTATION:SOMATIC' {
-    queue = 'nextflow-task-ondemand-4cpu_32gb-nvme_ssd'
+    queue = 'nextflow-task-ondemand-4cpu_32gb-ebs'
     cpus = 4
     memory = 30.GB
   }
@@ -187,9 +176,9 @@ process {
     errorStrategy = 'retry'
     maxRetries = 1
 
-    queue =  { task.attempt == 1 ? 'nextflow-task-ondemand-4cpu_32gb-nvme_ssd' : 'nextflow-task-ondemand-8cpu_64gb-nvme_ssd' }
-    cpus =   { task.attempt == 1 ? 4                                           : 8                                           }
-    memory = { task.attempt == 1 ? 30.GB                                       : 60.GB                                       }
+    queue =  { task.attempt == 1 ? 'nextflow-task-ondemand-4cpu_32gb-ebs' : 'nextflow-task-ondemand-8cpu_64gb-ebs' }
+    cpus =   { task.attempt == 1 ? 4                                      : 8                                      }
+    memory = { task.attempt == 1 ? 30.GB                                  : 60.GB                                  }
   }
 
   withName: '.*:LINX_ANNOTATION:(?:GERMLINE|SOMATIC)' {
@@ -202,7 +191,7 @@ process {
     errorStrategy = 'retry'
     maxRetries = 1
 
-    queue = 'nextflow-task-ondemand-8cpu_64gb-nvme_ssd'
+    queue = 'nextflow-task-ondemand-8cpu_64gb-ebs'
     cpus = 8
     memory = 60.GB
   }
@@ -217,7 +206,7 @@ process {
 
     // TODO(SW): can use much less memory for this process; create new CPU queue or determine whether performance over fusion is good enough for nextflow-task-16cpu_32gb
 
-    queue = 'nextflow-task-ondemand-8cpu_32gb-nvme_ssd'
+    queue = 'nextflow-task-ondemand-8cpu_32gb-ebs'
     cpus = 8
     memory = 30.GB
     time = 24.h
@@ -230,25 +219,25 @@ process {
   }
 
   withName: 'LILAC' {
-    queue = 'nextflow-task-ondemand-4cpu_32gb-nvme_ssd'
+    queue = 'nextflow-task-ondemand-4cpu_32gb-ebs'
     cpus = 4
     memory = 30.GB
   }
 
   withName: '.*:LILAC_CALLING:EXTRACTCONTIG' {
-    queue = 'nextflow-task-ondemand-4cpu_32gb-nvme_ssd'
+    queue = 'nextflow-task-ondemand-4cpu_32gb-ebs'
     cpus = 4
     memory = 30.GB
   }
 
   withName: '.*:LILAC_CALLING:REALIGNREADS' {
-    queue = 'nextflow-task-ondemand-4cpu_32gb-nvme_ssd'
+    queue = 'nextflow-task-ondemand-4cpu_32gb-ebs'
     cpus = 4
     memory = 30.GB
   }
 
   withName: '.*:LILAC_CALLING:SLICEBAM' {
-    queue = 'nextflow-task-ondemand-4cpu_32gb-nvme_ssd'
+    queue = 'nextflow-task-ondemand-4cpu_32gb-ebs'
     cpus = 4
     memory = 30.GB
   }
@@ -260,7 +249,7 @@ process {
   }
 
   withName: 'VIRUSBREAKEND' {
-    queue = 'nextflow-task-ondemand-8cpu_64gb-nvme_ssd'
+    queue = 'nextflow-task-ondemand-8cpu_64gb-ebs'
     cpus = 8
     memory = 60.GB
   }
@@ -272,7 +261,7 @@ process {
   }
 
   withName: 'ISOFOX' {
-    queue = 'nextflow-task-ondemand-8cpu_32gb-nvme_ssd'
+    queue = 'nextflow-task-ondemand-8cpu_32gb-ebs'
     cpus = 8
     memory = 30.GB
   }
@@ -284,7 +273,7 @@ process {
   }
 
   withName: 'SAMTOOLS_FLAGSTAT' {
-    queue = 'nextflow-task-ondemand-2cpu_16gb-nvme_ssd'
+    queue = 'nextflow-task-ondemand-2cpu_16gb-ebs'
     cpus = 2
     memory = 14.GB
   }

--- a/application/pipeline-stacks/oncoanalyser/assets/nextflow_aws.template.config
+++ b/application/pipeline-stacks/oncoanalyser/assets/nextflow_aws.template.config
@@ -27,8 +27,7 @@ process {
   executor = 'awsbatch'
   scratch = '/scratch/'
 
-  // NOTE(SW): using docker.runOptions in 23.10.01 causes `--network host` to be included twice, triggering an error in Docker
-  containerOptions = '--network host'
+  containerOptions = '--env LD_LIBRARY_PATH=/opt/awscliv2/aws-cli/v2/current/dist'
 
   resourceLabels = {
     return [

--- a/application/pipeline-stacks/oncoanalyser/assets/nextflow_aws.template.config
+++ b/application/pipeline-stacks/oncoanalyser/assets/nextflow_aws.template.config
@@ -182,9 +182,9 @@ process {
   }
 
   withName: '.*:LINX_ANNOTATION:(?:GERMLINE|SOMATIC)' {
-    executor = 'local'
-    cpus = 1
-    memory = 12.GB
+    queue = 'nextflow-task-ondemand-2cpu_16gb-ebs'
+    cpus = 2
+    memory = 14.GB
   }
 
   withName: '.*:LINX_PLOTTING:VISUALISER' {
@@ -197,9 +197,9 @@ process {
   }
 
   withName: '.*:LINX_PLOTTING:REPORT' {
-    executor = 'local'
-    cpus = 1
-    memory = 12.GB
+    queue = 'nextflow-task-ondemand-2cpu_16gb-ebs'
+    cpus = 2
+    memory = 14.GB
   }
 
   withName: 'BAMTOOLS' {
@@ -213,9 +213,9 @@ process {
   }
 
   withName: 'CHORD' {
-    executor = 'local'
-    cpus = 1
-    memory = 12.GB
+    queue = 'nextflow-task-ondemand-2cpu_16gb-ebs'
+    cpus = 2
+    memory = 14.GB
   }
 
   withName: 'LILAC' {
@@ -243,9 +243,9 @@ process {
   }
 
   withName: 'SIGS' {
-    executor = 'local'
-    cpus = 1
-    memory = 12.GB
+    queue = 'nextflow-task-ondemand-2cpu_16gb-ebs'
+    cpus = 2
+    memory = 14.GB
   }
 
   withName: 'VIRUSBREAKEND' {
@@ -255,9 +255,9 @@ process {
   }
 
   withName: 'VIRUSINTERPRETER' {
-    executor = 'local'
-    cpus = 1
-    memory = 12.GB
+    queue = 'nextflow-task-ondemand-2cpu_16gb-ebs'
+    cpus = 2
+    memory = 14.GB
   }
 
   withName: 'ISOFOX' {
@@ -267,9 +267,9 @@ process {
   }
 
   withName: 'CUPPA' {
-    executor = 'local'
-    cpus = 1
-    memory = 12.GB
+    queue = 'nextflow-task-ondemand-2cpu_16gb-ebs'
+    cpus = 2
+    memory = 14.GB
   }
 
   withName: 'SAMTOOLS_FLAGSTAT' {
@@ -279,15 +279,15 @@ process {
   }
 
   withName: 'ORANGE' {
-    executor = 'local'
-    cpus = 1
-    memory = 12.GB
+    queue = 'nextflow-task-ondemand-2cpu_16gb-ebs'
+    cpus = 2
+    memory = 14.GB
   }
 
   withName: 'CUSTOM_DUMPSOFTWAREVERSIONS' {
-    executor = 'local'
-    cpus = 1
-    memory = 12.GB
+    queue = 'nextflow-task-ondemand-2cpu_16gb-ebs'
+    cpus = 2
+    memory = 14.GB
   }
 
 }

--- a/application/pipeline-stacks/oncoanalyser/assets/run-v2.sh
+++ b/application/pipeline-stacks/oncoanalyser/assets/run-v2.sh
@@ -58,10 +58,10 @@ CUSTOM_CONFIG_PATH="custom.config"
 ## FUNCTIONS ##
 print_help_text() {
   cat <<EOF
-Usage example: run-v2.sh --manifest-json-str '{"inputs": {"mode": "wgts"...}, "engine_parameters": {"portal_run_id": ...}}'
+Usage example: run-v2.sh --manifest-json '{"inputs": {"mode": "wgts"...}, "engine_parameters": {"portal_run_id": ...}}'
 
 Options:
-  --manifest-json-str STR           Manifest json
+  --manifest-json STR           Manifest json
 
 Documentation:
   Manifest json should look like the following:

--- a/application/pipeline-stacks/oncoanalyser/assets/run.sh
+++ b/application/pipeline-stacks/oncoanalyser/assets/run.sh
@@ -252,10 +252,6 @@ get_hmf_refdata_from_ssm() {
   get_ssm_parameter_value "/nextflow_stack/oncoanalyser/refdata_hmf"
 }
 
-get_virusbreakend_db_from_ssm() {
-  get_ssm_parameter_value "/nextflow_stack/oncoanalyser/refdata_virusbreakend"
-}
-
 get_genomes_path_from_ssm() {
   get_ssm_parameter_value "/nextflow_stack/oncoanalyser/refdata_genomes"
 }
@@ -617,7 +613,6 @@ nextflow \
     --genome_type "alt" \
     --force_genome \
     --ref_data_hmf_data_path "s3://$(get_hmf_refdata_from_ssm)/" \
-    --ref_data_virusbreakenddb_path "s3://$(get_virusbreakend_db_from_ssm)/" \
     --outdir "${output_results_dir}/"
 
 # Upload data cleanly

--- a/application/pipeline-stacks/sash/Dockerfile
+++ b/application/pipeline-stacks/sash/Dockerfile
@@ -3,7 +3,7 @@ FROM docker.io/continuumio/miniconda3:23.10.0-1
 # Set package versions and other info
 # Generic
 ARG JQ_VERSION="1.6"
-ARG NEXTFLOW_VERSION="23.10.1"
+ARG NEXTFLOW_VERSION="25.04.3"
 ARG OPENJDK_VERSION="17.0.10"
 ARG PARALLEL_VERSION="20230322"
 ARG RCLONE_VERSION="1.62.2"

--- a/application/pipeline-stacks/sash/assets/nextflow_aws.template.config
+++ b/application/pipeline-stacks/sash/assets/nextflow_aws.template.config
@@ -133,11 +133,5 @@ process {
     cpus = 16
     memory = 60.GB
   }
-
-  withName: 'CUSTOM_DUMPSOFTWAREVERSIONS' {
-    queue = 'nextflow-task-ondemand-2cpu_16gb-ebs'
-    cpus = 2
-    memory = 14.GB
-  }
 }
 

--- a/application/pipeline-stacks/sash/assets/nextflow_aws.template.config
+++ b/application/pipeline-stacks/sash/assets/nextflow_aws.template.config
@@ -1,7 +1,3 @@
-plugins {
-  id 'nf-amazon'
-}
-
 aws {
   batch {
     jobRole = '__BATCH_INSTANCE_ROLE__'

--- a/application/pipeline-stacks/sash/assets/nextflow_aws.template.config
+++ b/application/pipeline-stacks/sash/assets/nextflow_aws.template.config
@@ -128,10 +128,16 @@ process {
     memory = 14.GB
   }
 
+  withName: 'ESVEE_CALL' {
+    queue = 'nextflow-task-ondemand-16cpu_64gb-ebs'
+    cpus = 16
+    memory = 60.GB
+  }
+
   withName: 'CUSTOM_DUMPSOFTWAREVERSIONS' {
     queue = 'nextflow-task-ondemand-2cpu_16gb-ebs'
     cpus = 2
     memory = 14.GB
   }
-
 }
+

--- a/application/pipeline-stacks/sash/assets/nextflow_aws.template.config
+++ b/application/pipeline-stacks/sash/assets/nextflow_aws.template.config
@@ -109,7 +109,7 @@ process {
     memory = 14.GB
   }
 
-  withName: '.*:LINX_PLOTTING:VISUALISER' {
+  withName: '.*:LINX_PLOTTING:LINX_VISUALISER' {
     errorStrategy = 'retry'
     maxRetries = 1
 
@@ -118,7 +118,7 @@ process {
     memory = 60.GB
   }
 
-  withName: '.*:LINX_PLOTTING:REPORT' {
+  withName: '.*:LINX_PLOTTING:LINXREPORT' {
     queue = 'nextflow-task-ondemand-2cpu_16gb-ebs'
     cpus = 2
     memory = 14.GB

--- a/application/pipeline-stacks/sash/assets/nextflow_aws.template.config
+++ b/application/pipeline-stacks/sash/assets/nextflow_aws.template.config
@@ -65,12 +65,6 @@ process {
     memory = 30.GB
   }
 
-  withName: '.*:GRIPSS_FILTERING:(?:GERMLINE|SOMATIC)' {
-    queue = 'nextflow-task-ondemand-4cpu_32gb-ebs'
-    cpus = 4
-    memory = 30.GB
-  }
-
   withName: 'BOLT_SV_SOMATIC_ANNOTATE' {
     queue = 'nextflow-task-ondemand-4cpu_32gb-ebs'
     cpus = 4

--- a/application/pipeline-stacks/sash/assets/nextflow_aws.template.config
+++ b/application/pipeline-stacks/sash/assets/nextflow_aws.template.config
@@ -7,6 +7,8 @@ aws {
     jobRole = '__BATCH_INSTANCE_ROLE__'
     cliPath = '/opt/awscliv2/bin/aws'
     volumes = '/scratch'
+    // NOTE(QC): Test using containerOptions to set LD_LIBRARY_PATH for zlibc.so.6 error
+    containerOptions = '--env LD_LIBRARY_PATH=/opt/awscliv2/aws-cli/v2/current/dist/'
   }
 }
 

--- a/application/pipeline-stacks/sash/assets/nextflow_aws.template.config
+++ b/application/pipeline-stacks/sash/assets/nextflow_aws.template.config
@@ -10,6 +10,8 @@ process {
   executor = 'awsbatch'
   scratch = '/scratch/'
 
+  containerOptions = '--env LD_LIBRARY_PATH=/opt/awscliv2/aws-cli/v2/current/dist'
+
   resourceLabels = {
     return [
       'Stack': 'NextflowStack',

--- a/application/pipeline-stacks/sash/assets/run-v2.sh
+++ b/application/pipeline-stacks/sash/assets/run-v2.sh
@@ -34,10 +34,10 @@ CUSTOM_CONFIG_PATH="custom.config"
 ## FUNCTIONS ##
 print_help_text() {
   cat <<EOF
-Usage example: run-v2.sh --manifest-json-str '{"inputs": {"mode": "wgts"...}, "engine_parameters": {"portal_run_id": ...}}'
+Usage example: run-v2.sh --manifest-json '{"inputs": {"mode": "wgts"...}, "engine_parameters": {"portal_run_id": ...}}'
 
 Options:
-  --manifest-json-str STR           Manifest json
+  --manifest-json STR           Manifest json
 
 Documentation:
   Manifest json should look like the following:

--- a/application/pipeline-stacks/sash/assets/run.sh
+++ b/application/pipeline-stacks/sash/assets/run.sh
@@ -37,6 +37,7 @@ Options:
   --output_scratch_dir DIR      Output directory for scratch
 
   --resume_nextflow_dir FILE    Previous .nextflow/ directory used to resume a run (S3 URI)
+  --stub_run                    Enable stub run mode for testing workflow logic
 EOF
 }
 
@@ -100,6 +101,10 @@ while [ $# -gt 0 ]; do
     --resume_nextflow_dir)
       resume_nextflow_dir="${2%/}"
       shift 1
+    ;;
+
+    --stub_run)
+      stub_run="true"
     ;;
 
     -h|--help)
@@ -400,6 +405,9 @@ EOF
 nextflow_args=''
 if [[ -n "${resume_nextflow_dir:-}" ]]; then
   nextflow_args+=' -resume'
+fi
+if [[ "${stub_run:-}" == "true" ]]; then
+  nextflow_args+=' -stub'
 fi
 
 ## END NEXFLOW ARGS ##

--- a/application/pipeline-stacks/star-align-nf/assets/nextflow_aws.template.config
+++ b/application/pipeline-stacks/star-align-nf/assets/nextflow_aws.template.config
@@ -1,25 +1,14 @@
-plugins {
-  id 'nf-amazon'
-}
-
-fusion {
-  enabled = true
-}
-
-wave {
-  enabled = true
-}
-
 aws {
   batch {
     jobRole = '__BATCH_INSTANCE_ROLE__'
-    volumes = '/mnt/local_ephemeral/:/tmp/'
+    cliPath = '/opt/awscliv2/bin/aws'
+    volumes = '/scratch'
   }
 }
 
 process {
   executor = 'awsbatch'
-  scratch = false
+  scratch = '/scratch/'
 
   // NOTE(SW): using docker.runOptions in 23.10.01 causes `--network host` to be included twice, triggering an error in Docker
   containerOptions = '--network host'
@@ -37,19 +26,19 @@ process {
     // NOTE(SW): Batch/ECS instances unable to pull quay.io/biocontainers/star:2.7.3a--0 without error; fixed in next star-align-nf release
     container = 'docker.io/scwatts/star:2.7.3a--1'
 
-    queue = 'nextflow-task-ondemand-8cpu_64gb-nvme_ssd'
+    queue = 'nextflow-task-ondemand-8cpu_64gb-ebs'
     cpus = 8
     memory = 60.GB
   }
 
   withName: 'SAMTOOLS_SORT' {
-    queue = 'nextflow-task-ondemand-4cpu_16gb-nvme_ssd'
+    queue = 'nextflow-task-ondemand-4cpu_16gb-ebs'
     cpus = 4
     memory = 14.GB
   }
 
   withName: 'GATK4_MARKDUPLICATES' {
-    queue = 'nextflow-task-ondemand-2cpu_16gb-nvme_ssd'
+    queue = 'nextflow-task-ondemand-2cpu_16gb-ebs'
     cpus = 1
     memory = 14.GB
   }

--- a/application/pipeline-stacks/star-align-nf/assets/nextflow_aws.template.config
+++ b/application/pipeline-stacks/star-align-nf/assets/nextflow_aws.template.config
@@ -10,8 +10,7 @@ process {
   executor = 'awsbatch'
   scratch = '/scratch/'
 
-  // NOTE(SW): using docker.runOptions in 23.10.01 causes `--network host` to be included twice, triggering an error in Docker
-  containerOptions = '--network host'
+  containerOptions = '--env LD_LIBRARY_PATH=/opt/awscliv2/aws-cli/v2/current/dist'
 
   resourceLabels = {
     return [

--- a/application/pipeline-stacks/star-align-nf/assets/nextflow_aws.template.config
+++ b/application/pipeline-stacks/star-align-nf/assets/nextflow_aws.template.config
@@ -44,9 +44,9 @@ process {
   }
 
   withName: 'CUSTOM_DUMPSOFTWAREVERSIONS' {
-    executor = 'local'
-    cpus = 1
-    memory = 12.GB
+    queue = 'nextflow-task-ondemand-2cpu_16gb-ebs'
+    cpus = 2
+    memory = 14.GB
   }
 
 }

--- a/application/settings.ts
+++ b/application/settings.ts
@@ -114,7 +114,7 @@ export class Oncoanalyser extends Shared {
 
 
 export class Sash extends Shared {
-  readonly versionTag = 'v0.6.0'
+  readonly versionTag = 'v0.6.0-dev'
 
   getSsmParameters() {
     return new Map<string, string>([

--- a/application/settings.ts
+++ b/application/settings.ts
@@ -97,7 +97,6 @@ export class Oncoanalyser extends Shared {
       ...super.getS3Data().entries(),
       ['refdataGenomesPath', 'genomes'],
       ['refdataHmfPath', 'hmf_reference_data/hmftools/5.34_38--2'],
-      ['refDataVirusbreakendDbPath', 'databases/virusbreakend/virusbreakenddb_20210401'],
     ]);
   }
 
@@ -106,7 +105,6 @@ export class Oncoanalyser extends Shared {
       ...super.getSsmParameters().entries(),
       [`/nextflow_stack/${this.workflowName}/refdata_genomes`, `${this.getRefdataBasePath()}/${this.getS3Data().get('refdataGenomesPath')!}`],
       [`/nextflow_stack/${this.workflowName}/refdata_hmf`, `${this.getRefdataBasePath()}/${this.getS3Data().get('refdataHmfPath')!}`],
-      [`/nextflow_stack/${this.workflowName}/refdata_virusbreakend`, `${this.getRefdataBasePath()}/${this.getS3Data().get('refDataVirusbreakendDbPath')!}`],
       [`/nextflow_stack/${this.workflowName}/pipeline_version_tag`, this.versionTag],
     ]);
   }

--- a/application/settings.ts
+++ b/application/settings.ts
@@ -90,7 +90,7 @@ export class StarAlignNf extends Shared {
 
 
 export class Oncoanalyser extends Shared {
-  readonly versionTag = '42ee926'
+  readonly versionTag = '2.0.0'
 
   getS3Data() {
     return new Map<string, string>([

--- a/application/settings.ts
+++ b/application/settings.ts
@@ -96,7 +96,7 @@ export class Oncoanalyser extends Shared {
     return new Map<string, string>([
       ...super.getS3Data().entries(),
       ['refdataGenomesPath', 'genomes'],
-      ['refdataHmfPath', 'hmf_reference_data/hmftools/5.34_38--2'],
+      ['refdataHmfPath', 'hmf_reference_data/hmftools/hmf_pipeline_resources.38_v2.0--3/'],
     ]);
   }
 

--- a/application/settings.ts
+++ b/application/settings.ts
@@ -9,7 +9,7 @@ export const taskQueueTypes = [
 
 export const taskInstanceStorageTypes = [
   constants.InstanceStorageType.EbsOnly,
-  constants.InstanceStorageType.NvmeSsdOnly,
+  //constants.InstanceStorageType.NvmeSsdOnly,
 ];
 
 export const maxvCpusDefault = 128;

--- a/application/settings.ts
+++ b/application/settings.ts
@@ -114,7 +114,7 @@ export class Oncoanalyser extends Shared {
 
 
 export class Sash extends Shared {
-  readonly versionTag = 'v0.5.0'
+  readonly versionTag = 'v0.6.0'
 
   getSsmParameters() {
     return new Map<string, string>([


### PR DESCRIPTION
### Combined PR

This branch merges the work from:

- [#124 – Bump sash version](https://github.com/umccr/nextflow-stack/pull/124)  
- [#125 – Bump oncoanalyser: 2.0.0](https://github.com/umccr/nextflow-stack/pull/125)  
- [#126 – Disable Nextflow Fusion](https://github.com/umccr/nextflow-stack/pull/126)  

Additional change: **explicitly set `platform: linux/amd64` for all `DockerImageAsset` builds**

---


