### PR TITLE
bump Ubuntu standard:7.0

### DIFF
--- a/deployment/codepipeline-stack.ts
+++ b/deployment/codepipeline-stack.ts
@@ -69,7 +69,7 @@ export class CodePipelineStack extends Stack {
       }),
       codeBuildDefaults: {
           buildEnvironment: {
-            buildImage: LinuxBuildImage.STANDARD_6_0,
+            buildImage: LinuxBuildImage.STANDARD_7_0,
             computeType: ComputeType.LARGE
           },
           // we need to give the codebuild engines permissions to assume a role in DEV - in order that they


### PR DESCRIPTION
Resolves a CodePipeline failure
The build was failing with a WebAssembly.Module() compile error due to an outdated Node.js version in the default CodeBuild environment.

[Slack Thread](https://umccr.slack.com/archives/C02LGHE2G/p1750380700721619?thread_ts=1749517392.703169&cid=C02LGHE2G)