### PR TITLE
Update run-v2.sh for OA v2.0 RNA workflow

### DIFF
--- a/application/pipeline-stacks/oncoanalyser/assets/run-v2.sh
+++ b/application/pipeline-stacks/oncoanalyser/assets/run-v2.sh
@@ -451,8 +451,8 @@ generate_wgts_dna_rna_to_samplesheet(){
           "sample_id": .inputs.tumor_dna_sample_id,
           "sample_type": "tumor",
           "sequence_type": "dna",
-          "filetype": "bam_markdups",
-          "filepath": "\(.inputs.dna_oncoanalyser_analysis_uri)alignments/dna/\(.inputs.tumor_dna_sample_id).markdups.bam"
+          "filetype": "bam_redux",
+          "filepath": "\(.inputs.dna_oncoanalyser_analysis_uri)alignments/dna/\(.inputs.tumor_dna_sample_id).redux.bam"
         },
         {
           "group_id": "\(.inputs.tumor_dna_sample_id)_\(.inputs.normal_dna_sample_id)_\(.inputs.tumor_rna_sample_id)",
@@ -460,8 +460,8 @@ generate_wgts_dna_rna_to_samplesheet(){
           "sample_id": .inputs.normal_dna_sample_id,
           "sample_type": "normal",
           "sequence_type": "dna",
-          "filetype": "bam_markdups",
-          "filepath": "\(.inputs.dna_oncoanalyser_analysis_uri)alignments/dna/\(.inputs.normal_dna_sample_id).markdups.bam"
+          "filetype": "bam_redux",
+          "filepath": "\(.inputs.dna_oncoanalyser_analysis_uri)alignments/dna/\(.inputs.normal_dna_sample_id).redux.bam"
         },
         {
           "group_id": "\(.inputs.tumor_dna_sample_id)_\(.inputs.normal_dna_sample_id)_\(.inputs.tumor_rna_sample_id)",
@@ -478,8 +478,8 @@ generate_wgts_dna_rna_to_samplesheet(){
           "sample_id": .inputs.tumor_dna_sample_id,
           "sample_type": "tumor",
           "sequence_type": "dna",
-          "filetype": "bamtools",
-          "filepath": "\(.inputs.dna_oncoanalyser_analysis_uri)bamtools/\(.inputs.tumor_dna_sample_id).wgsmetrics"
+          "filetype": "bamtools_dir",
+          "filepath": "\(.inputs.dna_oncoanalyser_analysis_uri)bamtools/"
         },
         {
           "group_id": "\(.inputs.tumor_dna_sample_id)_\(.inputs.normal_dna_sample_id)_\(.inputs.tumor_rna_sample_id)",
@@ -487,26 +487,8 @@ generate_wgts_dna_rna_to_samplesheet(){
           "sample_id": .inputs.normal_dna_sample_id,
           "sample_type": "normal",
           "sequence_type": "dna",
-          "filetype": "bamtools",
-          "filepath": "\(.inputs.dna_oncoanalyser_analysis_uri)bamtools/\(.inputs.normal_dna_sample_id).wgsmetrics"
-        },
-        {
-          "group_id": "\(.inputs.tumor_dna_sample_id)_\(.inputs.normal_dna_sample_id)_\(.inputs.tumor_rna_sample_id)",
-          "subject_id": .inputs.subject_id,
-          "sample_id": .inputs.tumor_dna_sample_id,
-          "sample_type": "tumor",
-          "sequence_type": "dna",
-          "filetype": "flagstat",
-          "filepath": "\(.inputs.dna_oncoanalyser_analysis_uri)flagstats/\(.inputs.tumor_dna_sample_id).flagstat"
-        },
-        {
-          "group_id": "\(.inputs.tumor_dna_sample_id)_\(.inputs.normal_dna_sample_id)_\(.inputs.tumor_rna_sample_id)",
-          "subject_id": .inputs.subject_id,
-          "sample_id": .inputs.normal_dna_sample_id,
-          "sample_type": "normal",
-          "sequence_type": "dna",
-          "filetype": "flagstat",
-          "filepath": "\(.inputs.dna_oncoanalyser_analysis_uri)flagstats/\(.inputs.normal_dna_sample_id).flagstat"
+          "filetype": "bamtools_dir",
+          "filepath": "\(.inputs.dna_oncoanalyser_analysis_uri)bamtools/"
         },
         {
           "group_id": "\(.inputs.tumor_dna_sample_id)_\(.inputs.normal_dna_sample_id)_\(.inputs.tumor_rna_sample_id)",

--- a/application/pipeline-stacks/oncoanalyser/assets/run-v2.sh
+++ b/application/pipeline-stacks/oncoanalyser/assets/run-v2.sh
@@ -457,11 +457,47 @@ generate_wgts_dna_rna_to_samplesheet(){
         {
           "group_id": "\(.inputs.tumor_dna_sample_id)_\(.inputs.normal_dna_sample_id)_\(.inputs.tumor_rna_sample_id)",
           "subject_id": .inputs.subject_id,
+          "sample_id": .inputs.tumor_dna_sample_id,
+          "sample_type": "tumor",
+          "sequence_type": "dna",
+          "filetype": "redux_jitter_tsv",
+          "filepath": "\(.inputs.dna_oncoanalyser_analysis_uri)alignments/dna/\(.inputs.tumor_dna_sample_id).jitter_params.tsv"
+        },
+        {
+          "group_id": "\(.inputs.tumor_dna_sample_id)_\(.inputs.normal_dna_sample_id)_\(.inputs.tumor_rna_sample_id)",
+          "subject_id": .inputs.subject_id,
+          "sample_id": .inputs.tumor_dna_sample_id,
+          "sample_type": "tumor",
+          "sequence_type": "dna",
+          "filetype": "redux_ms_tsv",
+          "filepath": "\(.inputs.dna_oncoanalyser_analysis_uri)alignments/dna/\(.inputs.tumor_dna_sample_id).ms_table.tsv.gz"
+        },
+        {
+          "group_id": "\(.inputs.tumor_dna_sample_id)_\(.inputs.normal_dna_sample_id)_\(.inputs.tumor_rna_sample_id)",
+          "subject_id": .inputs.subject_id,
           "sample_id": .inputs.normal_dna_sample_id,
           "sample_type": "normal",
           "sequence_type": "dna",
           "filetype": "bam_redux",
           "filepath": "\(.inputs.dna_oncoanalyser_analysis_uri)alignments/dna/\(.inputs.normal_dna_sample_id).redux.bam"
+        },
+        {
+          "group_id": "\(.inputs.tumor_dna_sample_id)_\(.inputs.normal_dna_sample_id)_\(.inputs.tumor_rna_sample_id)",
+          "subject_id": .inputs.subject_id,
+          "sample_id": .inputs.normal_dna_sample_id,
+          "sample_type": "normal",
+          "sequence_type": "dna",
+          "filetype": "redux_jitter_tsv",
+          "filepath": "\(.inputs.dna_oncoanalyser_analysis_uri)alignments/dna/\(.inputs.normal_dna_sample_id).jitter_params.tsv"
+        },
+        {
+          "group_id": "\(.inputs.tumor_dna_sample_id)_\(.inputs.normal_dna_sample_id)_\(.inputs.tumor_rna_sample_id)",
+          "subject_id": .inputs.subject_id,
+          "sample_id": .inputs.normal_dna_sample_id,
+          "sample_type": "normal",
+          "sequence_type": "dna",
+          "filetype": "redux_ms_tsv",
+          "filepath": "\(.inputs.dna_oncoanalyser_analysis_uri)alignments/dna/\(.inputs.normal_dna_sample_id).ms_table.tsv.gz"
         },
         {
           "group_id": "\(.inputs.tumor_dna_sample_id)_\(.inputs.normal_dna_sample_id)_\(.inputs.tumor_rna_sample_id)",

--- a/application/pipeline-stacks/oncoanalyser/assets/run-v2.sh
+++ b/application/pipeline-stacks/oncoanalyser/assets/run-v2.sh
@@ -515,7 +515,7 @@ generate_wgts_dna_rna_to_samplesheet(){
           "sample_type": "tumor",
           "sequence_type": "dna",
           "filetype": "bamtools_dir",
-          "filepath": "\(.inputs.dna_oncoanalyser_analysis_uri)bamtools/"
+          "filepath": "\(.inputs.dna_oncoanalyser_analysis_uri)bamtools/\(.inputs.tumor_dna_sample_id)_\(.inputs.normal_dna_sample_id)_\(.inputs.tumor_dna_sample_id)_bamtools/"
         },
         {
           "group_id": "\(.inputs.tumor_dna_sample_id)_\(.inputs.normal_dna_sample_id)_\(.inputs.tumor_rna_sample_id)",
@@ -524,7 +524,7 @@ generate_wgts_dna_rna_to_samplesheet(){
           "sample_type": "normal",
           "sequence_type": "dna",
           "filetype": "bamtools_dir",
-          "filepath": "\(.inputs.dna_oncoanalyser_analysis_uri)bamtools/"
+          "filepath": "\(.inputs.dna_oncoanalyser_analysis_uri)bamtools/\(.inputs.tumor_dna_sample_id)_\(.inputs.normal_dna_sample_id)_\(.inputs.normal_dna_sample_id)_bamtools/"
         },
         {
           "group_id": "\(.inputs.tumor_dna_sample_id)_\(.inputs.normal_dna_sample_id)_\(.inputs.tumor_rna_sample_id)",


### PR DESCRIPTION
Update files pass as input from OA v2.0 DNA workflow to OA v2.0 DNA/RNA

- BAM inputs – use `*.redux.bam` instead of `*.markdups.bam`
- Redux QC tables added
    - `*_jitter_params.tsv` – filetype: `redux_jitter_tsv`
    -  `*_ms_table.tsv.gz` – filetype: `redux_ms_tsv`
- Remove per-sample `*.flagstat`; point OA v2 at a bamtools_dir/ that holds all metrics.
- Sample-sheet paths – tumour and normal DNA rows now resolve to the bamtools sub-dir.