### PR TITLE
Fix Batch queue-mapping mismatch for sash's heavier processes

### DIFF
--- a/application/pipeline-stacks/sash/assets/nextflow_aws.template.config
+++ b/application/pipeline-stacks/sash/assets/nextflow_aws.template.config
@@ -30,9 +30,9 @@ process {
   }
 
   withName: 'BOLT_SMLV_SOMATIC_ANNOTATE' {
-    queue = 'nextflow-task-ondemand-4cpu_32gb-ebs'
-    cpus = 4
-    memory = 30.GB
+    queue = 'nextflow-task-ondemand-8cpu_64gb-ebs'
+    cpus = 8
+    memory = 60.GB
   }
 
   withName: 'BOLT_SMLV_SOMATIC_FILTER' {
@@ -42,9 +42,9 @@ process {
   }
 
   withName: '.*PAVE_SOMATIC' {
-    queue = 'nextflow-task-ondemand-2cpu_16gb-ebs'
-    cpus = 2
-    memory = 14.GB
+    queue = 'nextflow-task-ondemand-8cpu_64gb-ebs'
+    cpus = 8
+    memory = 60.GB
   }
 
   withName: 'BOLT_SMLV_SOMATIC_REPORT' {
@@ -78,9 +78,9 @@ process {
   }
 
   withName: 'PURPLE' {
-    queue = 'nextflow-task-ondemand-4cpu_32gb-ebs'
-    cpus = 4
-    memory = 30.GB
+    queue = 'nextflow-task-ondemand-8cpu_64gb-ebs'
+    cpus = 8
+    memory = 60.GB
   }
 
   withName: 'BOLT_OTHER_PURPLE_BAF_PLOT' {
@@ -90,15 +90,39 @@ process {
   }
 
   withName: 'BOLT_OTHER_CANCER_REPORT' {
-    queue = 'nextflow-task-ondemand-2cpu_16gb-ebs'
-    cpus = 2
-    memory = 14.GB
+    queue = 'nextflow-task-ondemand-8cpu_64gb-ebs'
+    cpus = 8
+    memory = 60.GB
   }
 
   withName: 'BOLT_OTHER_MULTIQC_REPORT' {
     queue = 'nextflow-task-ondemand-2cpu_16gb-ebs'
     cpus = 2
     memory = 14.GB
+  }
+
+  withName: 'DECOMP_MISC_DATA' {
+    queue = 'nextflow-task-ondemand-2cpu_16gb-ebs'
+    cpus = 2
+    memory = 14.GB
+  }
+
+  withName: 'SIGRAP_HRDETECT' {
+    queue = 'nextflow-task-ondemand-2cpu_16gb-ebs'
+    cpus = 2
+    memory = 14.GB
+  }
+
+  withName: 'SIGRAP_MUTPAT' {
+    queue = 'nextflow-task-ondemand-8cpu_64gb-ebs'
+    cpus = 8
+    memory = 60.GB
+  }
+
+  withName: 'VCF2MAF' {
+    queue = 'nextflow-task-ondemand-8cpu_64gb-ebs'
+    cpus = 8
+    memory = 60.GB
   }
 
   withName: '.*:LINX_ANNOTATION:(?:GERMLINE|SOMATIC)' {


### PR DESCRIPTION
## Summary

sash 0.7.0 added 4 new processes (`SIGRAP_MUTPAT`, `SIGRAP_HRDETECT`, `VCF2MAF`,
`DECOMP_MISC_DATA`) and relabelled 2 existing ones (`BOLT_SMLV_SOMATIC_ANNOTATE`,
`BOLT_OTHER_CANCER_REPORT`) to the heavier `process_medium_memory` label (8cpu/64GB), but
`application/pipeline-stacks/sash/assets/nextflow_aws.template.config` was never updated
to match. `SIGRAP_MUTPAT` had zero queue mapping and fell to an undersized default;
`PURPLE` and `PAVE_SOMATIC` were also undersized relative to their real `conf/base.config`
labels.

Effect: AWS Batch's `MISCONFIGURATION:JOB_RESOURCE_REQUIREMENT` on a mismatch like this is
permanent — the job can never fit any instance type the queue offers, so the run stalls
indefinitely rather than erroring or retrying.

## Fix

Adds `withName` blocks for `DECOMP_MISC_DATA`, `SIGRAP_HRDETECT`, `SIGRAP_MUTPAT`,
`VCF2MAF`; bumps `BOLT_SMLV_SOMATIC_ANNOTATE`, `BOLT_OTHER_CANCER_REPORT`, `PAVE_SOMATIC`,
`PURPLE` to the `8cpu_64gb-ebs` queue (already deployed — this file is a runtime template
asset, no `cdk deploy` needed).

## Validation

Held back on purpose pending a real run against the fix — that validation is done. The
2026-07-19 bolt#33/#35/#36 + sash#59 SEQC-II run (see [sash#62 comment](https://github.com/umccr/sash/issues/62#issuecomment-5187564863))
originally stalled on exactly this misconfiguration, was resumed with this fix applied in
place, and completed successfully: `Pipeline completed successfully`,
`WorkflowStats[succeededCount=14; cachedCount=9; failedCount=0; ignoredCount=0;
pendingCount=0]`. `SIGRAP_MUTPAT` and `PURPLE` — the two processes actually stuck at the
time — both moved `RUNNABLE` → `STARTING` within ~1 minute of the corrected queue mapping
landing, confirmed via `aws batch describe-jobs`.

Commit: `0291aad` on `fix/sash-batch-queue-mappings`.

Also worth a separate follow-up (not fixed by this PR, calling out for visibility): the
Batch compute environments use `allocationStrategy: BEST_FIT`, so a single unplaceable job
head-of-line-blocks the whole queue behind it — `BEST_FIT_PROGRESSIVE` would avoid that.
And interrupting a nextflow run (Ctrl-C) leaves its submitted Batch jobs `RUNNABLE`, not
auto-cancelled, which can then block a later `-resume` on the same queue.
